### PR TITLE
Fix confusion around domain concepts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog will not be updated for content updates.
 ----------------
 
 ## Next Release
+* Fix domain concept confusion on Tracks. **Backwards incompatible**
 * **Your contribution here**
 
 ## v1.0.3.0 (2016-10-21)

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -42,7 +42,11 @@ module Trackler
     end
 
     def implementations
-      @implementations ||= Implementations.new(id, repository, problems, root)
+      @implementations ||= Implementations.new(id, repository, active_slugs, root)
+    end
+
+    def problems
+      @problems ||= implementations.map(&:problem)
     end
 
     def checklist_issue
@@ -67,20 +71,6 @@ module Trackler
       end
     end
 
-    %w(exercises deprecated foregone).each do |name|
-      define_method name do
-        config[name] || []
-      end
-    end
-
-    def problems
-      exercises.empty? ? exercises_in_deprecated_key : exercises.map { |ex| ex["slug"] }
-    end
-
-    def exercises_in_deprecated_key
-      config["problems"] || []
-    end
-
     def test_pattern
       if config.key?('test_pattern')
         Regexp.new(config['test_pattern'])
@@ -97,10 +87,6 @@ module Trackler
       Image.new(File.join(dir, file_path))
     end
 
-    def slugs
-      problems + foregone + deprecated
-    end
-
     def doc_format
       default_format = 'md'
       path = File.join(dir, "docs", "*.*")
@@ -112,6 +98,34 @@ module Trackler
     end
 
     private
+
+    # Every slug mentioned in the configuration.
+    def slugs
+      active_slugs + foregone_slugs + deprecated_slugs
+    end
+
+    # The slugs for the problems that are currently in the track.
+    # We deprecated the old array of problem slugs in favor of an array
+    # containing richer metadata about a given exercise.
+    def active_slugs
+      __active_slugs__.empty? ? __active_slugs_deprecated_key__ : __active_slugs__
+    end
+
+    def __active_slugs__
+      (config["exercises"] || []).map { |ex| ex["slug"] }
+    end
+
+    def __active_slugs_deprecated_key__
+      config["problems"] || []
+    end
+
+    def foregone_slugs
+      config["foregone"] || []
+    end
+
+    def deprecated_slugs
+      config["deprecated"] || []
+    end
 
     def most_popular_format(path)
       formats = Dir.glob(path).map do |filename|

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -22,16 +22,18 @@ class TrackTest < Minitest::Test
     assert_equal 5, track.checklist_issue
     assert_equal nil, track.gitter
 
-    problems = %w(hello-world one two three)
-    assert_equal problems, track.problems
-    assert_equal ["apple"], track.foregone
-    assert_equal ["dog"], track.deprecated
-    assert_equal problems, track.implementations.map {|implementation|
+    slugs = %w(hello-world one two three)
+    assert_equal slugs, track.problems.map(&:slug)
+    assert_equal slugs, track.implementations.map {|implementation|
       implementation.problem.slug
     }
 
+    # This is a sanity-check to demonstrate that this fake
+    # track actually has both foregone and deprecated problems.
     slugs = %w(hello-world one two three apple dog)
-    assert_equal slugs, track.slugs
+    assert_equal ["apple"], track.send(:foregone_slugs)
+    assert_equal ["dog"], track.send(:deprecated_slugs)
+    assert_equal slugs, track.send(:slugs)
 
     # default test pattern
     assert_equal(/test/i, track.test_pattern)
@@ -39,8 +41,14 @@ class TrackTest < Minitest::Test
 
   def test_deprecated_problems
     track = Trackler::Track.new('fruit', FIXTURE_PATH)
-    problems = %w(apple banana cherry)
-    assert_equal problems, track.problems
+    slugs = %w(apple banana cherry)
+    assert_equal slugs, track.problems.map(&:slug)
+  end
+
+  def test_problems
+    track = Trackler::Track.new('fruit', FIXTURE_PATH)
+    slugs = %w(apple banana cherry)
+    assert_equal slugs, track.problems.map(&:slug)
   end
 
   def test_img


### PR DESCRIPTION
The 'problems' method on the track was actually returning slugs.

Yeah, really confusing.

* _slug_ - the URL-friendly identifier for an exercise.
* _problem_ - the generic, language-independent metadata for an exercise.
* _implementation_ - the language-specific implementation of an exercise.

The domain concepts are decent, provided we can get all the variables and
methods named consistently.

I think the origin of the confusion was that the configuration file
refers to a number of different sets of slugs:

- active exercises in the track
- foregone exercises (which will never be implemented)
- deprecated exercises (implemented, but no longer active)

So we were referring to the full set of slugs as "slugs", and needed
something to call the thing that represents "active slugs", and since
these used to be implemented in a key called "problems" in the config
file, it was probably a very short road to having a "problems" method
that simply returned the array directly from the config.

Then we deprecated the problems array in the config, to have a richer
data set for the active exercises for the track, under the "exercises"
key... and we couldn't just call the active slugs "exercises", because
that has more data.

To clear this up I've added more context to each of the lists of
slugs (active slugs, foregone slugs, and deprecated slugs), still
referring to the combined set as just plain "slugs". The active
slugs method uses some intentionally horribly named (but private)
methods, which at least makes it completely explicit what is going on.

Finally, I added a convenience method for problems that actually returns
problems, since we were previously accessing problems via the
implementations.

This breaks the backwards-compatibility of the `Trackler::Track` object, so we will need to bump the version to 2.0.0.0.

/cc @mhelmetag @nickborromeo mostly FYI since you've been doing some trackler refactoring.