### PR TITLE
Ignore test files in coverage report.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 ENV['RACK_ENV'] = 'test'
 
 require 'simplecov'
-SimpleCov.start
-SimpleCov.command_name "Run PID: #{$PROCESS_ID}"
+SimpleCov.start do
+  add_filter "/test/"
+  command_name "Run PID: #{$PROCESS_ID}"
+end
 
 gem 'minitest', '~> 5.2'
 require 'minitest/autorun'


### PR DESCRIPTION
When generating the coverage report exclude the test case files in the /test/ directory.