### PR TITLE
Fix exercism track todo page

### DIFF
--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -49,9 +49,9 @@ module Trackler
       end
     end
 
-    #TODO: Complete implementation
+    # Used by exercism.io/app/views/languages/_contribute_exercise.erb
     def readme_url
-      "fixme: #{caller.first}"
+      md_url
     end
 
     def test_suite_url

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -54,15 +54,25 @@ module Trackler
       "fixme: #{caller.first}"
     end
 
-    #TODO: Complete implementation
-    #TODO: Rename to test_data_url
-    def data
+    def test_suite_url
       "fixme: #{caller.first}"
     end
 
     #TODO: Complete implementation
+    #TODO: Rename to test_data_url
+    def data
+      test_suite_url
+    end
+
     def implementations
-      [ { 'url' => "fixme: #{caller.first}", 'track_id' => "I don't know my track_id'" } ]
+      # TODO: Accessing Trackler directly here is bad.
+      implementations = Trackler.implementations[slug]
+
+      # Format for exercism.io/app/views/languages/_contribute_exercise.erb
+      # TODO: update _contribute_exercise.erb to use the implemenation object.
+      implementations.map do |implementation|
+        { 'url' => implementation.git_url, 'track_id' => implementation.track_id }
+      end
     end
 
     private

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -49,6 +49,22 @@ module Trackler
       end
     end
 
+    #TODO: Complete implementation
+    def readme_url
+      "fixme: #{caller.first}"
+    end
+
+    #TODO: Complete implementation
+    #TODO: Rename to test_data_url
+    def data
+      "fixme: #{caller.first}"
+    end
+
+    #TODO: Complete implementation
+    def implementations
+      [ { 'url' => "fixme: #{caller.first}", 'track_id' => "I don't know my track_id'" } ]
+    end
+
     private
 
     def json

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -54,14 +54,13 @@ module Trackler
       md_url
     end
 
-    def test_suite_url
-      "fixme: #{caller.first}"
+    # Used by exercism.io/app/views/languages/_contribute_exercise.erb
+    def data
+      test_data_url
     end
 
-    #TODO: Complete implementation
-    #TODO: Rename to test_data_url
-    def data
-      test_suite_url
+    def test_data_url
+      json_url
     end
 
     def implementations

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -102,6 +102,10 @@ module Trackler
       active_slugs + foregone_slugs + deprecated_slugs
     end
 
+    def unimplemented_problems
+      Trackler.todos[id]
+    end
+
     private
 
     # The slugs for the problems that are currently in the track.
@@ -162,5 +166,6 @@ module Trackler
       path = File.join(dir, "docs", topic.upcase)
       Dir.glob("%s.*" % path).sort.first
     end
+
   end
 end

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'pathname'
 require 'org-ruby'
+require 'ostruct'
 require_relative 'file_bundle'
 
 module Trackler
@@ -80,7 +81,7 @@ module Trackler
     end
 
     def docs
-      Hash[TOPICS.zip(TOPICS.map { |topic| document_contents(topic) })]
+      OpenStruct.new( Hash[TOPICS.zip(TOPICS.map { |topic| document_contents(topic) })] )
     end
 
     def img(file_path)

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require 'trackler'
 require 'trackler/problem'
 
 class ProblemTest < Minitest::Test
@@ -40,5 +41,20 @@ class ProblemTest < Minitest::Test
 
   def test_no_such_problem
     refute Trackler::Problem.new('no-such-problem', FIXTURE_PATH).exists?
+  end
+
+  def test_implementations
+    mock_implemnetation = Minitest::Mock.new
+    mock_implemnetation.expect( :git_url, 'fake url' )
+    mock_implemnetation.expect( :track_id, 'fake track_id' )
+
+    # Temporarily return the format wanted by:
+    # exercism.io/app/views/languages/_contribute_exercise.erb
+    expected = [{'url' => 'fake url', 'track_id' => 'fake track_id'}]
+
+    Trackler.stub( :implementations, {'apple' => [mock_implemnetation] } ) do
+      problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+      assert_equal expected, problem.implementations
+    end
   end
 end

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -140,4 +140,10 @@ class TrackTest < Minitest::Test
     refute track.upcoming?
     assert track.planned?
   end
+
+  def test_unimplemented_problems
+    track = Trackler::Track.new('animal', FIXTURE_PATH)
+    expected = ['unimplemented_one','unimplemented_two']
+    assert_equal expected, track.unimplemented_problems
+  end
 end

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -81,6 +81,14 @@ class TrackTest < Minitest::Test
     assert_equal expected, track.docs
   end
 
+  # FIXME: this is a test of a Docs object, it doesn't really belong here.
+  def test_docs_accessible_as_object
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    expected = "Language Information\n"
+    assert_equal expected, track.docs.about
+  end
+
+  # FIXME: this is a test of a Docs object, it doesn't really belong here.
   # TODO: make exercism.io views consistent in what they expect docs to be.
   def test_docs_also_accessible_as_a_hash
     track = Trackler::Track.new('fake', FIXTURE_PATH)

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -71,14 +71,21 @@ class TrackTest < Minitest::Test
   def test_docs
     track = Trackler::Track.new('fake', FIXTURE_PATH)
 
-    expected = {
+    expected = OpenStruct.new({
       "about" => "Language Information\n",
       "installation" => "Installing\n",
       "tests" => "Running\n",
       "learning" => "Learning Fake!\n",
       "resources" => "",
-    }
+    })
     assert_equal expected, track.docs
+  end
+
+  # TODO: make exercism.io views consistent in what they expect docs to be.
+  def test_docs_also_accessible_as_a_hash
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    expected = "Language Information\n"
+    assert_equal expected, track.docs['about']
   end
 
   def test_doc_format

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -142,8 +142,11 @@ class TrackTest < Minitest::Test
   end
 
   def test_unimplemented_problems
-    track = Trackler::Track.new('animal', FIXTURE_PATH)
-    expected = ['unimplemented_one','unimplemented_two']
-    assert_equal expected, track.unimplemented_problems
+    # Shameless green: Stubbing Trackler here is a smell
+    expected = ['unimplemented_problem_one','unimplemented_problem_two']
+    Trackler.stub(:todos, {'animal' => expected } ) do
+      track = Trackler::Track.new('animal', FIXTURE_PATH)
+      assert_equal expected, track.unimplemented_problems
+    end
   end
 end

--- a/test/trackler_test.rb
+++ b/test/trackler_test.rb
@@ -7,4 +7,21 @@ class TracklerTest < Minitest::Test
     slugs = %w(banana cherry mango)
     assert_equal slugs, Trackler.todos["fake"].map(&:slug)
   end
+
+  def test_implementations
+    Trackler.use_fixture_data
+    result = Trackler.implementations
+    expected = ["dog", "hello-world", "one", "two", "three", "apple", "banana", "cherry"]
+    assert_equal expected, result.keys
+  end
+
+  def test_implementations_returns_hash_of_array_of_implementations
+    Trackler.use_fixture_data
+    result = Trackler.implementations
+    expected = Trackler::Implementation
+    assert result.all? { |k,v| v.first.class == expected }
+  end
+
+
+
 end


### PR DESCRIPTION
The exercism.io language track todo pages (eg: http://exercism.io/languages/ruby/todo) were showing an error page.

> Sorry! That's our fault!

This was due to various methods that were present in x-api not existing in Trackler.

`Track.unimplemented_problems`
`Problem.readme_url`
`Problem.data`
`Problem.implementations`

These methods were called by the views/languages templates: [_todo.erb](https://github.com/exercism/exercism.io/blob/master/app/views/languages/_todo.erb) and [_contribute_exercise.erb](https://github.com/exercism/exercism.io/blob/master/app/views/languages/_contribute_exercise.erb)

This patch adds those methods.

Will fix: https://github.com/exercism/exercism.io/issues/3266 (once Trackler gem is updated in exercism.io)
