### PR TITLE
Add support for SVG icons

### DIFF
--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -63,7 +63,7 @@ module Trackler
     end
 
     def icon
-      @icon ||= Image.new(File.join(dir, "img/icon.png"))
+      @icon ||= svg_icon.exists? ? svg_icon : png_icon
     end
 
     %w(language repository).each do |name|
@@ -162,6 +162,14 @@ module Trackler
     def document_filename(topic)
       path = File.join(dir, "docs", topic.upcase)
       Dir.glob("%s.*" % path).sort.first
+    end
+
+    def svg_icon
+      @svg_icon ||= Image.new(File.join(dir, "img/icon.svg"))
+    end
+
+    def png_icon
+      @png_icon ||= Image.new(File.join(dir, "img/icon.png"))
     end
   end
 end

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -118,7 +118,13 @@ class TrackTest < Minitest::Test
     refute Trackler::Track.new('nope', FIXTURE_PATH).exists?, "unexpected track 'nope'"
   end
 
-  def test_icon_path
+  def test_icon_path_svg
+    subject = Trackler::Track.new('fruit', FIXTURE_PATH)
+    expected = FIXTURE_PATH + '/tracks/fruit/img/icon.svg'
+    assert_equal expected, subject.icon_path
+  end
+
+  def test_icon_path_png
     subject = Trackler::Track.new('fake', FIXTURE_PATH)
     expected = FIXTURE_PATH + '/tracks/fake/img/icon.png'
     assert_equal expected, subject.icon_path


### PR DESCRIPTION
This defaults to using SVG if it's available, then falls back to assuming PNG.

This still puts the burden of finding the default Exercism icon on the caller, which we should eventually fix (serving a default icon if no track icon can be found). I'd like to use an svg for that, though, so I've not done it yet (I have a file with SVG of the logo in it, but I don't have the software to open it).

See exercism/exercism.io#2910

/cc @Insti 