### PR TITLE
Move `deprecated?` responsiblity into `Problem`.

### DIFF
--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -13,6 +13,10 @@ module Trackler
       !!description && !!metadata
     end
 
+    def deprecated?
+      @deprecated ||= File.exists?(common_metadata_path(deprecation_indicator_path))
+    end
+
     def name
       slug.split('-').map(&:capitalize).join(' ')
     end
@@ -87,6 +91,10 @@ module Trackler
 
     def description_path
       "exercises/%s/description.md" % slug
+    end
+
+    def deprecation_indicator_path
+      "exercises/%s/.deprecated" % slug
     end
 
     def repo_url(path)

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -28,17 +28,13 @@ module Trackler
     private
 
     def all
-      @all ||= dirs.reject { |problem| deprecated?(problem.slug) }
+      @all ||= dirs.reject(&:deprecated?)
     end
 
     def dirs
       @exercise_ids ||= Dir["%s/common/exercises/*/" % root].sort.map { |f|
         Problem.new(f[SLUG_PATTERN, 1], root)
       }
-    end
-
-    def deprecated?(slug)
-      File.exist?(File.join(root, "common", "exercises", slug, ".deprecated"))
     end
 
     def by_slug

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -104,4 +104,14 @@ class ProblemTest < Minitest::Test
     problem = Trackler::Problem.new('cherry', FIXTURE_PATH)
     assert_equal '', problem.source_markdown
   end
+
+  def test_problem_which_is_not_deprecated
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    refute problem.deprecated?
+  end
+
+  def test_problem_which_has_been_deprecated
+    problem = Trackler::Problem.new('fish', FIXTURE_PATH)
+    assert problem.deprecated?
+  end
 end


### PR DESCRIPTION
`Problem` already knows about 3 of the 4 possible problem related files
that can live in the exercise directory.

`metadata.yml`,`description.md`,`canonical-data.json`

This patch adds `.deprecated` so that they are now all covered.
And a `deprecated?` method to check if a problem is deprecated.

`Problems.deprecated?` was a private method so removing it should be safe.