### PR TITLE
Ignore invalid problems / Fix x-api compatability

### DIFF
--- a/fixtures/common/exercises/no-metadata/description.md
+++ b/fixtures/common/exercises/no-metadata/description.md
@@ -1,0 +1,1 @@
+This exercise should have no metadata.yml file.

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -17,6 +17,10 @@ module Trackler
       @deprecated ||= File.exists?(common_metadata_path(deprecation_indicator_path))
     end
 
+    def active?
+      exists? && !deprecated?
+    end
+
     def name
       slug.split('-').map(&:capitalize).join(' ')
     end

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -13,6 +13,10 @@ module Trackler
       !!description && !!metadata
     end
 
+    def deprecated?
+      @deprecated ||= File.exists?(common_metadata_path(deprecation_indicator_path))
+    end
+
     def name
       slug.split('-').map(&:capitalize).join(' ')
     end
@@ -87,6 +91,10 @@ module Trackler
 
     def description_path
       "exercises/%s/description.md" % slug
+    end
+
+    def deprecation_indicator_path
+      "exercises/%s/.deprecated" % slug
     end
 
     def repo_url(path)

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -28,7 +28,7 @@ module Trackler
     private
 
     def valid
-      @valid ||= dirs.reject(&:deprecated?)
+      @valid ||= dirs.select(&:active?)
     end
 
     def dirs

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -28,10 +28,10 @@ module Trackler
     private
 
     def valid
-      @valid ||= dirs.select(&:active?)
+      @valid ||= all.select(&:active?)
     end
 
-    def dirs
+    def all
       @exercise_ids ||= Dir["%s/common/exercises/*/" % root].sort.map { |f|
         Problem.new(f[SLUG_PATTERN, 1], root)
       }

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -3,8 +3,6 @@ module Trackler
   class Problems
     include Enumerable
 
-    SLUG_PATTERN = Regexp.new(".*\/exercises\/([^\/]*)\/")
-
     attr_reader :root
     def initialize(root)
       @root = root
@@ -32,9 +30,11 @@ module Trackler
     end
 
     def all
-      @exercise_ids ||= Dir["%s/common/exercises/*/" % root].sort.map { |f|
-        Problem.new(f[SLUG_PATTERN, 1], root)
-      }
+      @all_problems ||= exercise_slugs.map { |slug| Problem.new(slug, root) }
+    end
+
+    def exercise_slugs
+      Dir["%s/common/exercises/*/" % root].map { |path| File.basename(path) }.sort
     end
 
     def by_slug

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -9,7 +9,7 @@ module Trackler
     end
 
     def each
-      valid.each do |problem|
+      active.each do |problem|
         yield problem
       end
     end
@@ -25,8 +25,8 @@ module Trackler
 
     private
 
-    def valid
-      @valid ||= all.select(&:active?)
+    def active
+      @active ||= all.select(&:active?)
     end
 
     def all
@@ -43,7 +43,7 @@ module Trackler
 
     def problem_map
       hash = Hash.new { |_, k| Problem.new(k, root) }
-      valid.each do |problem|
+      active.each do |problem|
         hash[problem.slug] = problem
       end
       hash

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -11,7 +11,7 @@ module Trackler
     end
 
     def each
-      all.each do |problem|
+      valid.each do |problem|
         yield problem
       end
     end
@@ -27,8 +27,8 @@ module Trackler
 
     private
 
-    def all
-      @all ||= dirs.reject { |problem| deprecated?(problem.slug) }
+    def valid
+      @valid ||= dirs.reject { |problem| deprecated?(problem.slug) }
     end
 
     def dirs
@@ -47,7 +47,7 @@ module Trackler
 
     def problem_map
       hash = Hash.new { |_, k| Problem.new(k, root) }
-      all.each do |problem|
+      valid.each do |problem|
         hash[problem.slug] = problem
       end
       hash

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -28,17 +28,13 @@ module Trackler
     private
 
     def valid
-      @valid ||= dirs.reject { |problem| deprecated?(problem.slug) }
+      @valid ||= dirs.reject(&:deprecated?)
     end
 
     def dirs
       @exercise_ids ||= Dir["%s/common/exercises/*/" % root].sort.map { |f|
         Problem.new(f[SLUG_PATTERN, 1], root)
       }
-    end
-
-    def deprecated?(slug)
-      File.exist?(File.join(root, "common", "exercises", slug, ".deprecated"))
     end
 
     def by_slug

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -82,6 +82,10 @@ class ProblemTest < Minitest::Test
     assert_equal nil, problem.canonical_data_url
   end
 
+  def test_problem_with_no_metadata_yml
+    refute Trackler::Problem.new('no-metadata', FIXTURE_PATH).exists?
+  end
+
   def test_default_location
     problem = Trackler::Problem.new('mango', FIXTURE_PATH)
     assert_equal "## Source\n\nThe mango. [http://example.com](http://example.com)", problem.source_markdown

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -100,4 +100,14 @@ class ProblemTest < Minitest::Test
     problem = Trackler::Problem.new('cherry', FIXTURE_PATH)
     assert_equal '', problem.source_markdown
   end
+
+  def test_problem_which_is_not_deprecated
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    refute problem.deprecated?
+  end
+
+  def test_problem_which_has_been_deprecated
+    problem = Trackler::Problem.new('fish', FIXTURE_PATH)
+    assert problem.deprecated?
+  end
 end

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -110,4 +110,19 @@ class ProblemTest < Minitest::Test
     problem = Trackler::Problem.new('fish', FIXTURE_PATH)
     assert problem.deprecated?
   end
+
+  def test_problem_active?
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    assert problem.active?
+  end
+
+  def test_problem_which_not_active_because_it_is_deprecated
+    problem = Trackler::Problem.new('fish', FIXTURE_PATH)
+    refute problem.active?
+  end
+
+  def test_problem_which_not_active_because_it_does_not_exist
+    problem = Trackler::Problem.new('no-such-problem', FIXTURE_PATH)
+    refute problem.active?
+  end
 end

--- a/test/trackler/problems_test.rb
+++ b/test/trackler/problems_test.rb
@@ -6,12 +6,6 @@ class ProblemsTest < Minitest::Test
   def test_collection
     problems = Trackler::Problems.new(FIXTURE_PATH)
 
-    # can access it like an array
-    slugs = [
-      "apple", "banana", "cherry", "dog", "hello-world", "imbe", "mango", "one", "three", "two"
-    ]
-    assert_equal slugs, problems.map(&:slug)
-
     # can access it like a hash
     assert_equal "Cherry", problems["cherry"].name
 
@@ -22,5 +16,11 @@ class ProblemsTest < Minitest::Test
     slugs = %w(one two three apple)
     todos = %w(dog hello-world imbe banana cherry mango).sort
     assert_equal todos, problems - slugs
+  end
+
+  def test_only_valid_problems
+    problems = Trackler::Problems.new(FIXTURE_PATH)
+    slugs = %w(apple banana cherry dog hello-world imbe mango one three two)
+    assert_equal slugs, problems.map(&:slug)
   end
 end


### PR DESCRIPTION
Re-applies: https://github.com/exercism/trackler/commit/036a2a7f579aa29e4815cf32dd285105a810de0b

Fixes issues caused by x-api tests using the Trackler test fixtures.

Has been tested against the [current x-api master](https://github.com/exercism/x-api/tree/67cec8e670764a585cef16469869e85e6f07deea)

In https://github.com/exercism/trackler/commit/7bfbffe4fc1d5735db798d01ef33b08f94024b6e#commitcomment-20003912 @kytrinyx wrote: 

> Yes, this PR violated the assumption that no exercise, ever, will be missing a metadata.yml file. 

That is a reasonable assumption, and an important one so I think that Trackler should enforce this through some mechanism other than pure assumption.

Trackler now **Ignores** any exercises missing a `metadata.yml` file.
Any directory that does not contain a `metadata.yml` will be treated as not existing.

This allows all existing Trackler behaviour to work even in the presence of an invalid exercise.

Exercise validation can (and should) still be done at the x-common repository level to ensure that no invalid exercises are imported via git submodules.


