### PR TITLE
implementation: Test for symlinked files

### DIFF
--- a/fixtures/tracks/animal/.meta/include-in-fish.txt
+++ b/fixtures/tracks/animal/.meta/include-in-fish.txt
@@ -1,0 +1,1 @@
+This should get included in fish.

--- a/fixtures/tracks/animal/fish/included-via-symlink.txt
+++ b/fixtures/tracks/animal/fish/included-via-symlink.txt
@@ -1,0 +1,1 @@
+../.meta/include-in-fish.txt

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -59,6 +59,14 @@ class ImplementationTest < Minitest::Test
     assert_equal expected, implementation.readme
   end
 
+  def test_symlinked_file
+    problem = Trackler::Problem.new('fish', PATH)
+    implementation = Trackler::Implementation.new('animal', URL, problem, PATH)
+
+    expected = "This should get included in fish.\n"
+    assert_equal expected, implementation.files['included-via-symlink.txt']
+  end
+
   def test_missing_implementation
     problem = Trackler::Problem.new('apple', PATH)
     implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)


### PR DESCRIPTION
We have a use case in https://github.com/exercism/xhaskell/issues/442
where we would like to symlink files.

We have one common file that will get delivered with each exercise, and
we would only like to have to maintain one instance of it in the repo,
while symlinking it into all exercise directories.

This is a separate case than https://github.com/exercism/x-api/issues/29
because that talks about files that are not associated with any
particular exercise - their destination is a directory outside of any
exercise directory, whereas our destination is inside each exercise
directory.

For this case to work for us, we need trackler to correctly follow
symlinks present in an implementation. It currently does. In adding this
test, we request that this behaviour in the face of a symlink not
change in future trackler versions, for we have started to depend on it
as of https://github.com/exercism/xhaskell/pull/443