### PR TITLE
Make documentation image paths configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog will not be updated for content updates.
 ----------------
 
 ## Next Release
+* Make documentation image paths configurable
 * **Your contribution here**
 
 ## v2.0.3.0 (2016-11-29)

--- a/fixtures/tracks/fake/docs/INSTALLATION.org
+++ b/fixtures/tracks/fake/docs/INSTALLATION.org
@@ -1,1 +1,2 @@
 Installing
+![](/docs/img/test.jpg)

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -8,6 +8,7 @@ module Trackler
   # Track is a collection of exercises in a given language.
   class Track
     TOPICS = %w(about installation tests learning resources)
+    DEFAULT_IMAGE_PATH = "/docs/img"
 
     Image = Struct.new(:path) do
       def exists?
@@ -80,8 +81,8 @@ module Trackler
       end
     end
 
-    def docs
-      OpenStruct.new( Hash[TOPICS.zip(TOPICS.map { |topic| document_contents(topic) })] )
+    def docs(image_path = DEFAULT_IMAGE_PATH)
+      OpenStruct.new(docs_by_topic(image_path))
     end
 
     def img(file_path)
@@ -157,6 +158,16 @@ module Trackler
       else
         ''
       end
+    end
+
+    def docs_by_topic(image_path)
+      Hash[
+        TOPICS.zip(
+          TOPICS.map { |topic|
+            document_contents(topic).gsub(DEFAULT_IMAGE_PATH, image_path.gsub(Regexp.new("/$"), ""))
+          }
+        )
+      ]
     end
 
     def document_filename(topic)

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -73,12 +73,21 @@ class TrackTest < Minitest::Test
 
     expected = OpenStruct.new({
       "about" => "Language Information\n",
-      "installation" => "Installing\n",
+      "installation" => "Installing\n![](/docs/img/test.jpg)\n",
       "tests" => "Running\n",
       "learning" => "Learning Fake!\n",
       "resources" => "",
     })
     assert_equal expected, track.docs
+  end
+
+  def test_docs_with_alternate_image_path
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+
+    expected = "Installing\n![](/alt/test.jpg)\n"
+    assert_equal expected, track.docs("/alt").installation
+    # handles trailing slash
+    assert_equal expected, track.docs("/alt/").installation
   end
 
   def test_docs_accessible_as_object


### PR DESCRIPTION
In order to avoid hard-coding complete API paths for images, we need to add
a way to let the caller define where the documentation images can be found.

This also lets us see the images in the markdown on GitHub by defaulting to the
./docs/img path location.

It's kind of magical, but it makes a lot more sense than what we've been doing
and it makes it easier to contribute.

See exercism/exercism.io#3312