### PR TITLE
Handle full URLs as documentation images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog will not be updated for content updates.
 ----------------
 
 ## Next Release
+* Handle full URLs as documentation images
 * **Your contribution here**
 
 ## v2.0.4.0 (2016-12-16)

--- a/fixtures/tracks/fake/docs/TESTS.md
+++ b/fixtures/tracks/fake/docs/TESTS.md
@@ -1,1 +1,2 @@
 Running
+![](http://example.org/abc/docs/img/test.jpg)

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -161,10 +161,12 @@ module Trackler
     end
 
     def docs_by_topic(image_path)
+      src = Regexp.new("]\\(%s" % DEFAULT_IMAGE_PATH)
+      dst = "](%s" % image_path.gsub(Regexp.new("/$"), "")
       Hash[
         TOPICS.zip(
           TOPICS.map { |topic|
-            document_contents(topic).gsub(DEFAULT_IMAGE_PATH, image_path.gsub(Regexp.new("/$"), ""))
+            document_contents(topic).gsub(src, dst)
           }
         )
       ]

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -74,7 +74,7 @@ class TrackTest < Minitest::Test
     expected = OpenStruct.new({
       "about" => "Language Information\n",
       "installation" => "Installing\n![](/docs/img/test.jpg)\n",
-      "tests" => "Running\n",
+      "tests" => "Running\n![](http://example.org/abc/docs/img/test.jpg)\n",
       "learning" => "Learning Fake!\n",
       "resources" => "",
     })
@@ -88,6 +88,9 @@ class TrackTest < Minitest::Test
     assert_equal expected, track.docs("/alt").installation
     # handles trailing slash
     assert_equal expected, track.docs("/alt/").installation
+    # doesn't break absolute URLs
+    expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
+    assert_equal expected, track.docs("/alt").tests
   end
 
   def test_docs_accessible_as_object


### PR DESCRIPTION
We don't want to substitute the default image path if a full URL is used to refer
to an image in the track documentation.