### PR TITLE
Revert the test for symlinked files

### DIFF
--- a/fixtures/tracks/animal/.meta/include-in-fish.txt
+++ b/fixtures/tracks/animal/.meta/include-in-fish.txt
@@ -1,1 +1,0 @@
-This should get included in fish.

--- a/fixtures/tracks/animal/fish/included-via-symlink.txt
+++ b/fixtures/tracks/animal/fish/included-via-symlink.txt
@@ -1,1 +1,0 @@
-../.meta/include-in-fish.txt

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -59,14 +59,6 @@ class ImplementationTest < Minitest::Test
     assert_equal expected, implementation.readme
   end
 
-  def test_symlinked_file
-    problem = Trackler::Problem.new('fish', PATH)
-    implementation = Trackler::Implementation.new('animal', URL, problem, PATH)
-
-    expected = "This should get included in fish.\n"
-    assert_equal expected, implementation.files['included-via-symlink.txt']
-  end
-
   def test_missing_implementation
     problem = Trackler::Problem.new('apple', PATH)
     implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)


### PR DESCRIPTION
The symlink test is failing for me both locally and on CI.

Reverts exercism/trackler#12