### PR TITLE
Replace "assert_equal nil" with "assert_nil"

### DIFF
--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -79,7 +79,7 @@ class ProblemTest < Minitest::Test
 
   def test_track_with_no_canonical_data
     problem = Trackler::Problem.new('banana', FIXTURE_PATH)
-    assert_equal nil, problem.canonical_data_url
+    assert_nil problem.canonical_data_url
   end
 
   def test_problem_with_no_metadata_yml

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -20,7 +20,7 @@ class TrackTest < Minitest::Test
     assert_equal "Fake", track.language
     assert_equal "https://github.com/exercism/xfake", track.repository
     assert_equal 5, track.checklist_issue
-    assert_equal nil, track.gitter
+    assert_nil track.gitter
 
     slugs = %w(hello-world one two three)
     assert_equal slugs, track.problems.map(&:slug)
@@ -144,8 +144,7 @@ class TrackTest < Minitest::Test
 
   def test_icon_path_nonexisting
     subject = Trackler::Track.new('noicon', FIXTURE_PATH)
-    expected = nil
-    assert_equal expected, subject.icon_path
+    assert_nil subject.icon_path
   end
 
   def test_global_files


### PR DESCRIPTION
Fixes: #18 

Fix minitest warnings by replacing `assert_equal nil, result` with `assert_nil result`

Warnings were:
```
Use assert_nil if expecting nil from
/home/travis/build/exercism/trackler/test/trackler/problem_test.rb:82:in
`test_track_with_no_canonical_data'. This will fail in MT6.

Use assert_nil if expecting nil from
/home/travis/build/exercism/trackler/test/trackler/track_test.rb:23:in
`test_default_track'. This will fail in MT6.

Use assert_nil if expecting nil from
/home/travis/build/exercism/trackler/test/trackler/track_test.rb:148:in
`test_icon_path_nonexisting'. This will fail in MT6.
```