### PR TITLE
Extract Metadata concept from Problem

### DIFF
--- a/lib/trackler/metadata.rb
+++ b/lib/trackler/metadata.rb
@@ -1,0 +1,31 @@
+module Trackler
+  class Metadata
+    attr_accessor :file
+
+    def self.for_problem(problem:)
+      metadata = new
+      path = File.join(problem.root, "common", "exercises/%s/metadata.yml" % problem.slug)
+
+      metadata.file = if File.exists?(path)
+                        YAML.load(File.read(path))
+                      end
+      metadata
+    end
+
+    def blurb
+      file['blurb'].to_s.strip
+    end
+
+    def source
+      file['source'].to_s.strip
+    end
+
+    def source_url
+      file['source_url'].to_s.strip
+    end
+
+    def exists?
+      !file.nil?
+    end
+  end
+end

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -10,7 +10,7 @@ module Trackler
     end
 
     def exists?
-      !!description && !!metadata
+      !!description && !!metadata.exists?
     end
 
     def deprecated?
@@ -72,15 +72,15 @@ module Trackler
     end
 
     def blurb
-      metadata['blurb'].to_s.strip
+      metadata.blurb
     end
 
     def source
-      metadata['source'].to_s.strip
+      metadata.source
     end
 
     def source_url
-      metadata['source_url'].to_s.strip
+      metadata.source_url
     end
 
     private
@@ -106,11 +106,7 @@ module Trackler
     end
 
     def metadata
-      return @metadata unless @metadata.nil?
-      filename = common_metadata_path(metadata_path)
-      if File.exists?(filename)
-        @metadata = YAML.load(File.read(filename))
-      end
+      @metadata ||= Trackler::Metadata.for_problem(problem: self)
     end
 
     def common_metadata_path(path)

--- a/test/trackler/metadata_test.rb
+++ b/test/trackler/metadata_test.rb
@@ -1,0 +1,33 @@
+require_relative '../test_helper'
+require 'trackler/problem'
+
+class MetadataTest < Minitest::Test
+  def test_blurb
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    metadata = Trackler::Metadata.for_problem(problem: problem)
+    assert_equal 'Oh, hello.', metadata.blurb
+  end
+
+  def test_source
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    metadata = Trackler::Metadata.for_problem(problem: problem)
+    assert_equal 'The internet.', metadata.source
+  end
+
+  def test_source_url
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    metadata = Trackler::Metadata.for_problem(problem: problem)
+    assert_equal 'http://example.com', metadata.source_url
+  end
+
+  def test_metadata_url
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    assert_equal 'https://github.com/exercism/x-common/blob/master/exercises/hello-world/metadata.yml', problem.metadata_url
+  end
+
+  def test_problem_with_no_metadata_yml
+    problem = Trackler::Problem.new('no-metadata', FIXTURE_PATH)
+    metadata = Trackler::Metadata.for_problem(problem: problem)
+    refute metadata.exists?
+  end
+end


### PR DESCRIPTION
This is a prepatory refactoring for #22

No functional changes introduced in this change.

I'm extracting the concepts of creating and reading the metadata file out of Problem and into a new Metadata class. This means I now know the API that any metadata-like class will have to support.

The behavior of Metadata is tested in both its own test file as well as the existing Problem test file.