### PR TITLE
Remove unused, deprecated methods

### DIFF
--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -42,27 +42,6 @@ module Trackler
       text.empty? ? text : "## Source\n\n#{text}"
     end
 
-    ######
-    # Deprecated methods
-    # TODO: remove external references to these methods.
-    # found in: x-api
-    # NOT in: exercism.io, cli
-    # Anywhere else we need to look?
-    # Should this output a warning or raise an error?
-    def md_url
-      description_url
-    end
-
-    def json_url
-      canonical_data_url
-    end
-
-    def yaml_url
-      metadata_url
-    end
-    # End deprecated methods
-    ######
-
     def description_url
       description_object.url
     end

--- a/test/trackler/problem_test.rb
+++ b/test/trackler/problem_test.rb
@@ -33,19 +33,9 @@ class ProblemTest < Minitest::Test
     assert_equal 'https://github.com/exercism/x-common/blob/master/exercises/hello-world/metadata.yml', problem.metadata_url
   end
 
-  def test_deprecated_method_yaml_url
-    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
-    assert_equal 'https://github.com/exercism/x-common/blob/master/exercises/hello-world/metadata.yml', problem.yaml_url
-  end
-
   def test_description_url
     problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
     assert_equal 'https://github.com/exercism/x-common/blob/master/exercises/hello-world/description.md', problem.description_url
-  end
-
-  def test_deprecated_method_md_url
-    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
-    assert_equal 'https://github.com/exercism/x-common/blob/master/exercises/hello-world/description.md', problem.md_url
   end
 
   def test_source_markdown
@@ -71,11 +61,6 @@ class ProblemTest < Minitest::Test
   def test_canonical_data_url
     problem = Trackler::Problem.new('mango', FIXTURE_PATH)
     assert_equal "https://github.com/exercism/x-common/blob/master/exercises/mango/canonical-data.json", problem.canonical_data_url
-  end
-
-  def test_deprecated_method_json_url
-    problem = Trackler::Problem.new('mango', FIXTURE_PATH)
-    assert_equal "https://github.com/exercism/x-common/blob/master/exercises/mango/canonical-data.json", problem.json_url
   end
 
   def test_track_with_no_canonical_data


### PR DESCRIPTION
The usage of these methods was removed in https://github.com/exercism/x-api/pull/147