### PR TITLE
Add `image_path` keyword argument to Track#docs method.

### DIFF
--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -82,6 +82,9 @@ module Trackler
     end
 
     def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)
+      if positional_image_path_which_is_deprecated
+        warn "DEPRECATION WARNING:\ntrack.docs: Positional argument is deprected, please use keyword argument 'image_path:' instead\neg: track.docs(image_path: #{positional_image_path_which_is_deprecated.inspect})\n"
+      end
       OpenStruct.new(docs_by_topic(image_path || positional_image_path_which_is_deprecated || DEFAULT_IMAGE_PATH))
     end
 

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -81,8 +81,8 @@ module Trackler
       end
     end
 
-    def docs(image_path = DEFAULT_IMAGE_PATH)
-      OpenStruct.new(docs_by_topic(image_path))
+    def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)
+      OpenStruct.new(docs_by_topic(image_path || positional_image_path_which_is_deprecated || DEFAULT_IMAGE_PATH))
     end
 
     def img(file_path)

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -101,12 +101,6 @@ class TrackTest < Minitest::Test
     end
   end
 
-  def test_docs_with_alternate_image_path_using_keyword_argument
-    track = Trackler::Track.new('fake', FIXTURE_PATH)
-    expected = "Installing\n![](/keyword/test.jpg)\n"
-    assert_equal expected, track.docs(image_path: '/keyword').installation
-  end
-
   def test_docs_accessible_as_object
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     expected = "Language Information\n"

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -84,17 +84,13 @@ class TrackTest < Minitest::Test
   def test_docs_with_alternate_image_path
     track = Trackler::Track.new('fake', FIXTURE_PATH)
 
-    # This will now raise a deprecation warning (or 3)
-    _, err = capture_io do
-      expected = "Installing\n![](/alt/test.jpg)\n"
-      assert_equal expected, track.docs("/alt").installation
-      # handles trailing slash
-      assert_equal expected, track.docs("/alt/").installation
-      # doesn't break absolute URLs
-      expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
-      assert_equal expected, track.docs("/alt").tests
-    end
-    assert_match(/DEPRECATION WARNING/, err)
+    expected = "Installing\n![](/alt/test.jpg)\n"
+    assert_equal expected, track.docs(image_path: "/alt").installation
+    # handles trailing slash
+    assert_equal expected, track.docs(image_path: "/alt/").installation
+    # doesn't break absolute URLs
+    expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
+    assert_equal expected, track.docs(image_path: "/alt").tests
   end
 
   def test_docs_with_alternate_image_path_using_positional_argument

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -97,6 +97,14 @@ class TrackTest < Minitest::Test
     assert_match(/DEPRECATION WARNING/, err)
   end
 
+  def test_docs_with_alternate_image_path_using_positional_argument
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    assert_output nil, /DEPRECATION WARNING/ do
+      expected = "Installing\n![](/positional/test.jpg)\n"
+      assert_equal expected, track.docs('/positional').installation
+    end
+  end
+
   def test_docs_with_alternate_image_path_using_keyword_argument
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     expected = "Installing\n![](/keyword/test.jpg)\n"

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -93,6 +93,12 @@ class TrackTest < Minitest::Test
     assert_equal expected, track.docs("/alt").tests
   end
 
+  def test_docs_with_alternate_image_path_using_keyword_argument
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    expected = "Installing\n![](/keyword/test.jpg)\n"
+    assert_equal expected, track.docs(image_path: '/keyword').installation
+  end
+
   def test_docs_accessible_as_object
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     expected = "Language Information\n"

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -84,13 +84,17 @@ class TrackTest < Minitest::Test
   def test_docs_with_alternate_image_path
     track = Trackler::Track.new('fake', FIXTURE_PATH)
 
-    expected = "Installing\n![](/alt/test.jpg)\n"
-    assert_equal expected, track.docs("/alt").installation
-    # handles trailing slash
-    assert_equal expected, track.docs("/alt/").installation
-    # doesn't break absolute URLs
-    expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
-    assert_equal expected, track.docs("/alt").tests
+    # This will now raise a deprecation warning (or 3)
+    _, err = capture_io do
+      expected = "Installing\n![](/alt/test.jpg)\n"
+      assert_equal expected, track.docs("/alt").installation
+      # handles trailing slash
+      assert_equal expected, track.docs("/alt/").installation
+      # doesn't break absolute URLs
+      expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
+      assert_equal expected, track.docs("/alt").tests
+    end
+    assert_match(/DEPRECATION WARNING/, err)
   end
 
   def test_docs_with_alternate_image_path_using_keyword_argument


### PR DESCRIPTION
Fixes #28 

The method remains backwards-compatible by still accepting the positional
argument, but the keyword argument takes highest precedence.

Setting of the default value has been moved from the arguments to the
method body, this makes the signature look slightly different, but the
functionality is the same.

The method `warn` if the positional argument is used.
