### PR TITLE
Display exercise hints before track hints in Readme

### DIFF
--- a/fixtures/tracks/fruit/SETUP.md
+++ b/fixtures/tracks/fruit/SETUP.md
@@ -1,1 +1,1 @@
-Do stuff.
+The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.

--- a/fixtures/tracks/fruit/exercises/banana/HINTS.md
+++ b/fixtures/tracks/fruit/exercises/banana/HINTS.md
@@ -1,2 +1,3 @@
+* banana specific hints.
 * a hint
 * another hint

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -85,8 +85,8 @@ module Trackler
     def readme_body
       [
         problem.description,
-        track_hint,
         implementation_hint,
+        track_hint,
       ].reject(&:empty?).join("\n").strip
     end
 

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -55,7 +55,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('banana', PATH)
     implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
 
-    expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n* a hint\n* another hint\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
     assert_equal expected, implementation.readme
   end

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -46,7 +46,7 @@ class ImplementationTest < Minitest::Test
     expected = {
       "apple.ext" => "an apple a day keeps the doctor away\n",
       "apple.tst" => "assert 'apple'\n",
-      "README.md" => "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\nDo stuff.\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+      "README.md" => "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     }
     assert_equal expected, implementation.files
   end
@@ -55,7 +55,8 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('banana', PATH)
     implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
 
-    expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\nDo stuff.\n\n* a hint\n* another hint\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n* a hint\n* another hint\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+
     assert_equal expected, implementation.readme
   end
 
@@ -110,7 +111,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('apple', PATH)
     implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
 
-    assert_match /Do stuff/, implementation.readme
+    assert_match %r(The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.), implementation.readme
   end
 
   def test_readme_uses_track_hint_instead_of_setup


### PR DESCRIPTION
Fixes #26

This patch places the implementation specific hints before the track specific hints in the readme of an exercise leading to a more logical ordering of information in the readme that is displayed on the exercism.io site and delivered by the cli tool.

Note:  There is some additional 'noise' in this PR due to some modifications to the fixture files to help make the problem and solution more obvious.
