### PR TITLE
Minor: Fix typo in deprec(a)ted

### DIFF
--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -83,7 +83,7 @@ module Trackler
 
     def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)
       if positional_image_path_which_is_deprecated
-        warn "DEPRECATION WARNING:\ntrack.docs: Positional argument is deprected, please use keyword argument 'image_path:' instead\neg: track.docs(image_path: #{positional_image_path_which_is_deprecated.inspect})\n"
+        warn "DEPRECATION WARNING:\ntrack.docs: Positional argument is deprecated, please use keyword argument 'image_path:' instead\neg: track.docs(image_path: #{positional_image_path_which_is_deprecated.inspect})\n"
       end
       OpenStruct.new(docs_by_topic(image_path || positional_image_path_which_is_deprecated || DEFAULT_IMAGE_PATH))
     end


### PR DESCRIPTION
https://github.com/exercism/trackler/pull/29#discussion_r111963141

I don't type "deprecated" correctly every time, @kytrinyx notices every time.
So I fix them and try to remember to do better next time.

I probably should put a spellcheck in my pre-commit hook.
