### PR TITLE
Allow test pattern to take precedence over override pattern

### DIFF
--- a/fixtures/tracks/animal/exercises/dog/a_test_example_for.animal
+++ b/fixtures/tracks/animal/exercises/dog/a_test_example_for.animal
@@ -1,0 +1,1 @@
+example test

--- a/lib/trackler/file_bundle.rb
+++ b/lib/trackler/file_bundle.rb
@@ -5,9 +5,10 @@ module Trackler
   # It contains all the files that will be provided by the `exercism fetch` command
   # EXCEPT for those whose names match any of the ignore patterns.
   class FileBundle
-    def initialize(base_directory, ignore_patterns = [])
+    def initialize(base_directory, ignore_patterns = [], keep_pattern = nil)
       @base_directory = base_directory
       @ignore_patterns = ignore_patterns
+      @keep_pattern = keep_pattern
     end
 
     def zip
@@ -26,18 +27,23 @@ module Trackler
 
     private
 
-    attr_reader :base_directory, :ignore_patterns
+    attr_reader :base_directory, :ignore_patterns, :keep_pattern
 
     def all_files_below(dir)
       Pathname.glob("#{dir}/**/*", File::FNM_DOTMATCH)
     end
 
     def ignored?(file)
-      ignored_by_name?(file) || ignored_by_type?(file)
+      name = file.to_s.gsub(base_directory.to_s, "")
+      ignored_by_type?(file) || (!keep?(name) && ignored_by_name?(name))
     end
 
-    def ignored_by_name?(file)
-      ignore_patterns.any? { |pattern| file.to_s =~ pattern }
+    def keep?(filename)
+      (!!keep_pattern && filename =~ keep_pattern)
+    end
+
+    def ignored_by_name?(filename)
+      ignore_patterns.any? { |pattern| filename =~ pattern }
     end
 
     def ignored_by_type?(file)

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -18,7 +18,7 @@ module Trackler
       @repo = track.repository
       @root = Pathname.new(track.root)
       @problem = problem
-      @file_bundle = FileBundle.new(track_directory, IGNORE)
+      @file_bundle = FileBundle.new(track_directory, IGNORE, track.test_pattern)
     end
 
     def exists?

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -13,11 +13,11 @@ module Trackler
 
     attr_reader :track_id, :repo, :problem, :root, :file_bundle
     attr_writer :files
-    def initialize(track_id, repo, problem, root)
-      @track_id = track_id
-      @repo = repo
+    def initialize(track, problem)
+      @track_id = track.id
+      @repo = track.repository
+      @root = Pathname.new(track.root)
       @problem = problem
-      @root = Pathname.new(root)
       @file_bundle = FileBundle.new(track_directory, IGNORE)
     end
 

--- a/lib/trackler/implementations.rb
+++ b/lib/trackler/implementations.rb
@@ -25,7 +25,7 @@ module Trackler
 
     def all
       @all ||= slugs.map { |slug|
-        Implementation.new(track.id, repo, Problem.new(slug, root, track), root)
+        Implementation.new(track, Problem.new(slug, root, track))
       }
     end
 
@@ -35,7 +35,7 @@ module Trackler
 
     def implementation_map
       hash = Hash.new { |_, k|
-        Implementation.new(track.id, repo, Problem.new(k, root, track), root)
+        Implementation.new(track, Problem.new(k, root, track))
       }
       all.each do |impl|
         hash[impl.problem.slug] = impl

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -99,6 +99,15 @@ class ImplementationTest < Minitest::Test
     assert_equal expected, implementation.files.keys
   end
 
+  def test_never_ignores_explicit_matches_to_configured_test_pattern_regex
+    track = Trackler::Track.new('animal', FIXTURE_PATH)
+    problem = Trackler::Problem.new('dog', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track, problem)
+
+    expected = ["a_dog.animal", "a_dog_2.animal", "a_test_example_for.animal", "README.md"]
+    assert_equal expected, implementation.files.keys
+  end
+
   def test_readme_has_empty_string_for_track_hint_when_setup_file_does_not_exist
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     problem = Trackler::Problem.new('apple', FIXTURE_PATH)

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -3,13 +3,9 @@ require 'trackler/problem'
 require 'trackler/implementation'
 
 class ImplementationTest < Minitest::Test
-  PATH     = FIXTURE_PATH
-  TRACK_ID = 'fake'.freeze
-  URL      = '[REPO_URL]'.freeze
-  PROBLEM  = Trackler::Problem.new('hello-world', PATH)
-
   def test_zip
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, PROBLEM, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     # Our archive is not binary identically reproducable :(
     archive = implementation.zip
     assert_instance_of StringIO, archive
@@ -18,8 +14,8 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_implementation_with_extra_files
-    problem = Trackler::Problem.new('one', PATH)
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)
+    problem = Trackler::Problem.new('one', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
 
     expected = {
       "Fakefile" => "Autorun fake code\n",
@@ -38,9 +34,9 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_implementation_in_subdirectory
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
-    assert_equal "[REPO_URL]/tree/master/exercises/apple", implementation.git_url
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('fruit', "repo.url", problem, FIXTURE_PATH)
+    assert_equal "repo.url/tree/master/exercises/apple", implementation.git_url
     assert_match Regexp.new('exercises[\\/]apple'), implementation.exercise_dir
 
     expected = {
@@ -52,8 +48,8 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_language_and_implementation_specific_readme
-    problem = Trackler::Problem.new('banana', PATH)
-    implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
+    problem = Trackler::Problem.new('banana', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('fruit', "repo.url", problem, FIXTURE_PATH)
 
     expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
@@ -61,21 +57,22 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_symlinked_file
-    problem = Trackler::Problem.new('fish', PATH)
-    implementation = Trackler::Implementation.new('animal', URL, problem, PATH)
+    problem = Trackler::Problem.new('fish', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('animal', "repo.url", problem, FIXTURE_PATH)
 
     expected = "This should get included in fish.\n"
     assert_equal expected, implementation.files['included-via-symlink.txt']
   end
 
   def test_missing_implementation
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     refute implementation.exists?, "Not expecting apple to be implemented for track TRACK_ID"
   end
 
   def test_override_implementation_files
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, PROBLEM, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     files = { "filename" => "contents" }
     implementation.files = files
     assert_equal files, implementation.files
@@ -83,16 +80,16 @@ class ImplementationTest < Minitest::Test
 
   def test_ignores_example_files
     track_id = 'fruit'
-    problem = Trackler::Problem.new('imbe', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('imbe', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
     expected = ['imbe.txt', 'README.md']
     assert_equal expected, implementation.files.keys
   end
 
   def test_readme_has_empty_string_for_track_hint_when_setup_file_does_not_exist
     track_id = 'fake'
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     expected = "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     assert_equal expected, implementation.readme
@@ -100,24 +97,24 @@ class ImplementationTest < Minitest::Test
 
   def test_readme_uses_track_hint_in_precedence_of_setup
     track_id = 'animal'
-    problem = Trackler::Problem.new('dog', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('dog', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match /This is the content of the track hints file/, implementation.readme
   end
 
   def test_readme_uses_setup_when_track_hints_is_missing
     track_id = 'fruit'
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match %r(The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.), implementation.readme
   end
 
   def test_readme_uses_track_hint_instead_of_setup
     track_id = 'jewels'
-    problem = Trackler::Problem.new('hello-world', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match /This is the content of the track hints file/, implementation.readme
   end


### PR DESCRIPTION
If a file matches the test pattern explicitly, then it should not be removed from the implementation's file bundle.

This is necessary since the Go track is implementing example tests, which have example in the file name, but are not part of the reference solution.

The first two commits are refactorings.

1. Inline some constants that weren't helping readability
1. Change Implementation so that it is initialized with two objects (track and problem) rather than a problem object and a bunch of attributes. All the attributes exist in the track, and for the new behavior (added in the third commit) we also need the test pattern from the track.

See https://github.com/exercism/xgo/issues/621

@petertseng Would you have time to review this?