### PR TITLE
Customizable ignore pattern

### DIFF
--- a/fixtures/tracks/animal/config.json
+++ b/fixtures/tracks/animal/config.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/exercism/xanimal",
   "active": true,
   "test_pattern": "a.*animal",
+  "ignore_pattern": "[^_]example",
   "problems": [
     "dog"
   ],

--- a/fixtures/tracks/animal/exercises/dog/a_test_example_for.animal
+++ b/fixtures/tracks/animal/exercises/dog/a_test_example_for.animal
@@ -1,0 +1,1 @@
+example test

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -6,7 +6,6 @@ module Trackler
   class Implementation
     IGNORE = [
       Regexp.new("HINTS\.md$"),
-      Regexp.new("example", Regexp::IGNORECASE),
       Regexp.new("\/\.$"),
       Regexp.new("/\.meta/")
     ]
@@ -14,11 +13,16 @@ module Trackler
     attr_reader :track_id, :repo, :problem, :root, :file_bundle
     attr_writer :files
     def initialize(track, problem)
+      @track = track
       @track_id = track.id
       @repo = track.repository
       @root = Pathname.new(track.root)
       @problem = problem
-      @file_bundle = FileBundle.new(track_directory, IGNORE)
+      @file_bundle = FileBundle.new(track_directory, ignore)
+    end
+
+    def ignore
+      IGNORE + [Regexp.new(@track.ignore_pattern, Regexp::IGNORECASE)]
     end
 
     def exists?

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -10,13 +10,10 @@ module Trackler
       Regexp.new("/\.meta/")
     ]
 
-    attr_reader :track_id, :repo, :problem, :root, :file_bundle
+    attr_reader :track, :problem, :file_bundle
     attr_writer :files
     def initialize(track, problem)
       @track = track
-      @track_id = track.id
-      @repo = track.repository
-      @root = Pathname.new(track.root)
       @problem = problem
       @file_bundle = FileBundle.new(track_directory, ignore)
     end
@@ -55,7 +52,7 @@ module Trackler
     end
 
     def git_url
-      [repo, "tree/master", exercise_dir].join("/")
+      [track.repository, "tree/master", exercise_dir].join("/")
     end
 
     private
@@ -65,7 +62,8 @@ module Trackler
     end
 
     def track_dir
-      @track_dir ||= root.join('tracks', track_id)
+      root = Pathname.new(track.root)
+      @track_dir ||= root.join('tracks', track.id)
     end
 
     def assemble_readme

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -42,14 +42,6 @@ module Trackler
       @readme ||= assemble_readme
     end
 
-    def exercise_dir
-      if File.exist?(track.dir.join('exercises'))
-        File.join('exercises', problem.slug)
-      else
-        problem.slug
-      end
-    end
-
     def git_url
       [track.repository, "tree/master", exercise_dir].join("/")
     end
@@ -64,6 +56,14 @@ module Trackler
 
     def implementation_dir
       @implementation_dir ||= track.dir.join(exercise_dir)
+    end
+
+    def exercise_dir
+      if File.exist?(track.dir.join('exercises'))
+        File.join('exercises', problem.slug)
+      else
+        problem.slug
+      end
     end
 
     def assemble_readme

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -87,8 +87,8 @@ module Trackler
     def readme_body
       [
         problem.description,
-        implementation_hint,
-        track.hint,
+        implementation_hints,
+        track.hints,
       ].reject(&:empty?).join("\n").strip
     end
 
@@ -103,7 +103,7 @@ It's possible to submit an incomplete solution so you can see how others have co
       README
     end
 
-    def implementation_hint
+    def implementation_hints
       read File.join(implementation_dir, 'HINTS.md')
     end
 

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -88,7 +88,7 @@ module Trackler
       [
         problem.description,
         implementation_hint,
-        track_hint,
+        track.hint,
       ].reject(&:empty?).join("\n").strip
     end
 
@@ -101,14 +101,6 @@ module Trackler
 ## Submitting Incomplete Problems
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
       README
-    end
-
-    def track_hint
-      track_hints_filename = track.dir.join('exercises','TRACK_HINTS.md')
-      unless File.exist?(track_hints_filename)
-        track_hints_filename = track.dir.join('SETUP.md')
-      end
-      read track_hints_filename
     end
 
     def implementation_hint

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -43,7 +43,7 @@ module Trackler
     end
 
     def exercise_dir
-      if File.exist?(track_dir.join('exercises'))
+      if File.exist?(track.dir.join('exercises'))
         File.join('exercises', problem.slug)
       else
         problem.slug
@@ -63,12 +63,7 @@ module Trackler
     end
 
     def implementation_dir
-      @implementation_dir ||= track_dir.join(exercise_dir)
-    end
-
-    def track_dir
-      root = Pathname.new(track.root)
-      @track_dir ||= root.join('tracks', track.id)
+      @implementation_dir ||= track.dir.join(exercise_dir)
     end
 
     def assemble_readme
@@ -109,9 +104,9 @@ It's possible to submit an incomplete solution so you can see how others have co
     end
 
     def track_hint
-      track_hints_filename = track_dir.join('exercises','TRACK_HINTS.md')
+      track_hints_filename = track.dir.join('exercises','TRACK_HINTS.md')
       unless File.exist?(track_hints_filename)
-        track_hints_filename = track_dir.join('SETUP.md')
+        track_hints_filename = track.dir.join('SETUP.md')
       end
       read track_hints_filename
     end

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -5,7 +5,7 @@ module Trackler
   # Implementation is a language-specific implementation of an exercise.
   class Implementation
     IGNORE_PATTERNS = [
-      "HINTS\.md$",
+      "\/HINTS\.md$",
       "\/\.$",
       "/\.meta/"
     ]

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -4,10 +4,10 @@ require_relative 'file_bundle'
 module Trackler
   # Implementation is a language-specific implementation of an exercise.
   class Implementation
-    IGNORE = [
-      Regexp.new("HINTS\.md$"),
-      Regexp.new("\/\.$"),
-      Regexp.new("/\.meta/")
+    IGNORE_PATTERNS = [
+      "HINTS\.md$",
+      "\/\.$",
+      "/\.meta/"
     ]
 
     attr_reader :track, :problem
@@ -22,7 +22,9 @@ module Trackler
     end
 
     def ignore
-      IGNORE + [Regexp.new(@track.ignore_pattern, Regexp::IGNORECASE)]
+      (IGNORE_PATTERNS + [@track.ignore_pattern]).map do |pattern|
+        Regexp.new(pattern, Regexp::IGNORECASE)
+      end
     end
 
     def exists?

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -18,7 +18,7 @@ module Trackler
     end
 
     def file_bundle
-      @file_bundle ||= FileBundle.new(track_directory, ignore)
+      @file_bundle ||= FileBundle.new(track_directory, regexes_to_ignore)
     end
 
     def exists?
@@ -56,7 +56,7 @@ module Trackler
 
     private
 
-    def ignore
+    def regexes_to_ignore
       (IGNORE_PATTERNS + [@track.ignore_pattern]).map do |pattern|
         Regexp.new(pattern, Regexp::IGNORECASE)
       end

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -13,11 +13,11 @@ module Trackler
 
     attr_reader :track_id, :repo, :problem, :root, :file_bundle
     attr_writer :files
-    def initialize(track_id, repo, problem, root)
-      @track_id = track_id
-      @repo = repo
+    def initialize(track, problem)
+      @track_id = track.id
+      @repo = track.repository
+      @root = Pathname.new(track.root)
       @problem = problem
-      @root = Pathname.new(root)
       @file_bundle = FileBundle.new(track_directory, IGNORE)
     end
 

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -18,16 +18,16 @@ module Trackler
     end
 
     def file_bundle
-      @file_bundle ||= FileBundle.new(track_directory, regexes_to_ignore)
+      @file_bundle ||= FileBundle.new(implementation_dir, regexes_to_ignore)
     end
 
     def exists?
-      File.exist?(track_directory)
+      File.exist?(implementation_dir)
     end
 
     def files
       @files ||= Hash[file_bundle.paths.map {|path|
-        [path.relative_path_from(track_directory).to_s, File.read(path)]
+        [path.relative_path_from(implementation_dir).to_s, File.read(path)]
       }].merge("README.md" => readme)
     end
 
@@ -62,8 +62,8 @@ module Trackler
       end
     end
 
-    def track_directory
-      @track_directory ||= track_dir.join(exercise_dir)
+    def implementation_dir
+      @implementation_dir ||= track_dir.join(exercise_dir)
     end
 
     def track_dir
@@ -117,7 +117,7 @@ It's possible to submit an incomplete solution so you can see how others have co
     end
 
     def implementation_hint
-      read File.join(track_directory, 'HINTS.md')
+      read File.join(implementation_dir, 'HINTS.md')
     end
 
     def read(f)

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -21,12 +21,6 @@ module Trackler
       @file_bundle ||= FileBundle.new(track_directory, ignore)
     end
 
-    def ignore
-      (IGNORE_PATTERNS + [@track.ignore_pattern]).map do |pattern|
-        Regexp.new(pattern, Regexp::IGNORECASE)
-      end
-    end
-
     def exists?
       File.exist?(track_directory)
     end
@@ -61,6 +55,12 @@ module Trackler
     end
 
     private
+
+    def ignore
+      (IGNORE_PATTERNS + [@track.ignore_pattern]).map do |pattern|
+        Regexp.new(pattern, Regexp::IGNORECASE)
+      end
+    end
 
     def track_directory
       @track_directory ||= track_dir.join(exercise_dir)

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -10,12 +10,15 @@ module Trackler
       Regexp.new("/\.meta/")
     ]
 
-    attr_reader :track, :problem, :file_bundle
+    attr_reader :track, :problem
     attr_writer :files
     def initialize(track, problem)
       @track = track
       @problem = problem
-      @file_bundle = FileBundle.new(track_directory, ignore)
+    end
+
+    def file_bundle
+      @file_bundle ||= FileBundle.new(track_directory, ignore)
     end
 
     def ignore

--- a/lib/trackler/implementations.rb
+++ b/lib/trackler/implementations.rb
@@ -25,7 +25,7 @@ module Trackler
 
     def all
       @all ||= slugs.map { |slug|
-        Implementation.new(track.id, repo, Problem.new(slug, root, track), root)
+        Implementation.new(track, Problem.new(slug, root, track))
       }
     end
 
@@ -35,7 +35,7 @@ module Trackler
 
     def implementation_map
       hash = Hash.new { |_, k|
-        Implementation.new(track.id, repo, Problem.new(k, root, track), root)
+        Implementation.new(track, Problem.new(k, root, track))
       }
       all.each do |impl|
         hash[impl.problem.slug] = impl

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -82,11 +82,7 @@ module Trackler
     end
 
     def ignore_pattern
-      if config.key?('ignore_pattern')
-        config['ignore_pattern']
-      else
-        'example'
-      end
+      config.fetch('ignore_pattern', 'example')
     end
 
     def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -115,6 +115,10 @@ module Trackler
       active_slugs + foregone_slugs + deprecated_slugs
     end
 
+    def dir
+      root.join("tracks", id)
+    end
+
     private
 
     # The slugs for the problems that are currently in the track.
@@ -145,10 +149,6 @@ module Trackler
         File.extname(filename).sub(/^\./, '')
       end
       formats.max_by { |format| formats.count(format) }
-    end
-
-    def dir
-      root.join("tracks", id)
     end
 
     def config

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -115,6 +115,14 @@ module Trackler
       root.join("tracks", id)
     end
 
+    def hint
+      track_hints_filename = dir.join('exercises', 'TRACK_HINTS.md')
+      unless File.exist?(track_hints_filename)
+        track_hints_filename = dir.join('SETUP.md')
+      end
+      read track_hints_filename
+    end
+
     private
 
     # The slugs for the problems that are currently in the track.
@@ -190,6 +198,14 @@ module Trackler
 
     def png_icon
       @png_icon ||= Image.new(File.join(dir, "img/icon.png"))
+    end
+
+    def read(f)
+      if File.exist?(f)
+        File.read(f)
+      else
+        ""
+      end
     end
   end
 end

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -81,6 +81,14 @@ module Trackler
       end
     end
 
+    def ignore_pattern
+      if config.key?('ignore_pattern')
+        config['ignore_pattern']
+      else
+        'example'
+      end
+    end
+
     def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)
       if positional_image_path_which_is_deprecated
         warn "DEPRECATION WARNING:\ntrack.docs: Positional argument is deprecated, please use keyword argument 'image_path:' instead\neg: track.docs(image_path: #{positional_image_path_which_is_deprecated.inspect})\n"

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -115,7 +115,7 @@ module Trackler
       root.join("tracks", id)
     end
 
-    def hint
+    def hints
       track_hints_filename = dir.join('exercises', 'TRACK_HINTS.md')
       unless File.exist?(track_hints_filename)
         track_hints_filename = dir.join('SETUP.md')

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -99,6 +99,15 @@ class ImplementationTest < Minitest::Test
     assert_equal expected, implementation.files.keys
   end
 
+  def test_never_ignores_explicit_matches_to_configured_test_pattern_regex
+    track = Trackler::Track.new('animal', FIXTURE_PATH)
+    problem = Trackler::Problem.new('dog', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track, problem)
+
+    expected = ["a_dog.animal", "a_dog_2.animal", "a_test_example_for.animal", "README.md"]
+    assert_equal expected, implementation.files.keys
+  end
+
   def test_readme_has_empty_string_for_track_hint_when_setup_file_does_not_exist
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     problem = Trackler::Problem.new('apple', FIXTURE_PATH)

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -3,13 +3,9 @@ require 'trackler/problem'
 require 'trackler/implementation'
 
 class ImplementationTest < Minitest::Test
-  PATH     = FIXTURE_PATH
-  TRACK_ID = 'fake'.freeze
-  URL      = '[REPO_URL]'.freeze
-  PROBLEM  = Trackler::Problem.new('hello-world', PATH)
-
   def test_zip
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, PROBLEM, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     # Our archive is not binary identically reproducable :(
     archive = implementation.zip
     assert_instance_of StringIO, archive
@@ -18,8 +14,8 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_implementation_with_extra_files
-    problem = Trackler::Problem.new('one', PATH)
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)
+    problem = Trackler::Problem.new('one', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
 
     expected = {
       "Fakefile" => "Autorun fake code\n",
@@ -38,9 +34,9 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_implementation_in_subdirectory
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
-    assert_equal "[REPO_URL]/tree/master/exercises/apple", implementation.git_url
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('fruit', "repo.url", problem, FIXTURE_PATH)
+    assert_equal "repo.url/tree/master/exercises/apple", implementation.git_url
     assert_match Regexp.new('exercises[\\/]apple'), implementation.exercise_dir
 
     expected = {
@@ -52,8 +48,8 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_language_and_implementation_specific_readme
-    problem = Trackler::Problem.new('banana', PATH)
-    implementation = Trackler::Implementation.new('fruit', URL, problem, PATH)
+    problem = Trackler::Problem.new('banana', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('fruit', "repo.url", problem, FIXTURE_PATH)
 
     expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
@@ -61,21 +57,22 @@ class ImplementationTest < Minitest::Test
   end
 
   def test_symlinked_file
-    problem = Trackler::Problem.new('fish', PATH)
-    implementation = Trackler::Implementation.new('animal', URL, problem, PATH)
+    problem = Trackler::Problem.new('fish', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new('animal', "repo.url", problem, FIXTURE_PATH)
 
     expected = "This should get included in fish.\n"
     assert_equal expected, implementation.files['included-via-symlink.txt']
   end
 
   def test_missing_implementation
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     refute implementation.exists?, "Not expecting apple to be implemented for track TRACK_ID"
   end
 
   def test_override_implementation_files
-    implementation = Trackler::Implementation.new(TRACK_ID, URL, PROBLEM, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new("fake", "repo.url", problem, FIXTURE_PATH)
     files = { "filename" => "contents" }
     implementation.files = files
     assert_equal files, implementation.files
@@ -83,16 +80,16 @@ class ImplementationTest < Minitest::Test
 
   def test_ignores_example_files
     track_id = 'fruit'
-    problem = Trackler::Problem.new('imbe', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('imbe', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
     expected = ['imbe.txt', 'README.md']
     assert_equal expected, implementation.files.keys
   end
 
   def test_readme_has_empty_string_for_track_hint_when_setup_file_does_not_exist
     track_id = 'fake'
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     expected = "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     assert_equal expected, implementation.readme
@@ -100,24 +97,24 @@ class ImplementationTest < Minitest::Test
 
   def test_readme_uses_track_hint_in_precedence_of_setup
     track_id = 'animal'
-    problem = Trackler::Problem.new('dog', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('dog', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match /This is the content of the track hints file/, implementation.readme
   end
 
   def test_readme_uses_setup_when_track_hints_is_missing
     track_id = 'fruit'
-    problem = Trackler::Problem.new('apple', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('apple', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match %r(The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.), implementation.readme
   end
 
   def test_readme_uses_track_hint_instead_of_setup
     track_id = 'jewels'
-    problem = Trackler::Problem.new('hello-world', PATH)
-    implementation = Trackler::Implementation.new(track_id, URL, problem, PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track_id, "repo.url", problem, FIXTURE_PATH)
 
     assert_match /This is the content of the track hints file/, implementation.readme
   end

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -43,7 +43,6 @@ class ImplementationTest < Minitest::Test
     implementation = Trackler::Implementation.new(track, problem)
 
     assert_equal "https://example.com/exercism/xfruit/tree/master/exercises/apple", implementation.git_url
-    assert_match Regexp.new('exercises[\\/]apple'), implementation.exercise_dir
 
     expected = {
       "apple.ext" => "an apple a day keeps the doctor away\n",


### PR DESCRIPTION
This is an alternate solution to: https://github.com/exercism/trackler/pull/32

And allows tracks to provide their own `ignore_pattern` in `config.json` which will override the default of /`example`/

This is necessary since the Go track is implementing example tests, which have example in the file name, but are not part of the reference solution.

See exercism/xgo#621

The first two commits are @kytrinyx's refactorings.
 *  Inline some constants that weren't helping readability
 * Change Implementation so that it is initialized with two objects (track and problem) rather than a problem object and a bunch of attributes. All the attributes exist in the track, and for the new behavior (added in the third commit) we also need the test pattern from the track.

The third is the test that @kytrinyx wrote.
(git credited it to me because I only copied the bits I needed from her commit, I guess  could include the whole commit and then revert the changes I don't want to keep, if it's important.)

The fourth are the changes to support the custom ignore pattern in tracks.

This to me is much simpler than adding an extra condition under which files are NOT ignored.


