### PR TITLE
An `Implementation` is a `Problem`

### DIFF
--- a/lib/trackler.rb
+++ b/lib/trackler.rb
@@ -38,7 +38,7 @@ module Trackler
     @implementations = Hash.new { |h, k| h[k] = [] }
     tracks.each do |track|
       track.implementations.each do |implementation|
-        @implementations[implementation.problem.slug] << implementation
+        @implementations[implementation.slug] << implementation
       end
     end
     @implementations

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -72,7 +72,7 @@ module Trackler
     private
 
     def regexes_to_ignore
-      (IGNORE_PATTERNS + [@track.ignore_pattern]).map do |pattern|
+      (IGNORE_PATTERNS + [track.ignore_pattern]).map do |pattern|
         Regexp.new(pattern, Regexp::IGNORECASE)
       end
     end

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -87,18 +87,14 @@ module Trackler
 
     def assemble_readme
       <<-README
-# #{readme_title}
+# #{name}
 
 #{readme_body}
 
-#{readme_source}
+#{source_markdown}
 
 #{incomplete_solutions_body}
       README
-    end
-
-    def readme_title
-      name
     end
 
     def optional_blurb
@@ -113,10 +109,6 @@ module Trackler
           implementation_hints,
           track.hints,
         ].reject(&:empty?).join("\n").strip
-    end
-
-    def readme_source
-      source_markdown
     end
 
     def incomplete_solutions_body

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -10,6 +10,9 @@ module Trackler
       "/\.meta/"
     ]
 
+    extend Forwardable
+    def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug
+
     attr_reader :track, :problem
     def initialize(track, problem)
       @track = track
@@ -90,26 +93,25 @@ module Trackler
     end
 
     def readme_title
-      problem.name
+      name
     end
 
     def optional_blurb
-      blurb = problem.blurb
-      return '' if problem.description.start_with?(blurb)
+      return '' if description.start_with?(blurb)
       "#{blurb}\n\n"
     end
 
     def readme_body
       optional_blurb +
         [
-          problem.description,
+          description,
           implementation_hints,
           track.hints,
         ].reject(&:empty?).join("\n").strip
     end
 
     def readme_source
-      problem.source_markdown
+      source_markdown
     end
 
     def incomplete_solutions_body

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -13,7 +13,6 @@ module Trackler
     extend Forwardable
     def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug, :source, :metadata, :root, :active?, :deprecated?, :source_url, :description_url, :canonical_data_url, :metadata_url
 
-    attr_reader :track
     def initialize(track, problem)
       @track = track
       @problem = problem
@@ -70,6 +69,8 @@ module Trackler
     end
 
     private
+
+    attr_reader :track
 
     def regexes_to_ignore
       (IGNORE_PATTERNS + [track.ignore_pattern]).map do |pattern|

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -23,10 +23,6 @@ module Trackler
       @problem
     end
 
-    def file_bundle
-      @file_bundle ||= FileBundle.new(implementation_dir, regexes_to_ignore)
-    end
-
     def exists?
       File.exist?(implementation_dir)
     end
@@ -76,6 +72,10 @@ module Trackler
       (IGNORE_PATTERNS + [track.ignore_pattern]).map do |pattern|
         Regexp.new(pattern, Regexp::IGNORECASE)
       end
+    end
+
+    def file_bundle
+      @file_bundle ||= FileBundle.new(implementation_dir, regexes_to_ignore)
     end
 
     def implementation_dir

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -11,7 +11,7 @@ module Trackler
     ]
 
     extend Forwardable
-    def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug
+    def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug, :source, :metadata, :root, :active?, :deprecated?, :source_url, :description_url, :canonical_data_url, :metadata_url
 
     attr_reader :track, :problem
     def initialize(track, problem)

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -13,10 +13,15 @@ module Trackler
     extend Forwardable
     def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug, :source, :metadata, :root, :active?, :deprecated?, :source_url, :description_url, :canonical_data_url, :metadata_url
 
-    attr_reader :track, :problem
+    attr_reader :track
     def initialize(track, problem)
       @track = track
       @problem = problem
+    end
+
+    def problem
+      warn "DEPRECATION WARNING: The `problem` method is deprecated, Implementation can do everything that Problem can, so call the method directly."
+      @problem
     end
 
     def file_bundle

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -119,15 +119,8 @@ It's possible to submit an incomplete solution so you can see how others have co
     end
 
     def implementation_hints
-      read File.join(implementation_dir, 'HINTS.md')
-    end
-
-    def read(f)
-      if File.exist?(f)
-        File.read(f)
-      else
-        ""
-      end
+      hints_file = File.join(implementation_dir, 'HINTS.md')
+      File.exist?(hints_file) ? File.read(hints_file) : ''
     end
   end
 end

--- a/lib/trackler/implementations.rb
+++ b/lib/trackler/implementations.rb
@@ -21,6 +21,10 @@ module Trackler
       by_slug[slug]
     end
 
+    def length
+      all.length
+    end
+
     private
 
     def all
@@ -38,7 +42,7 @@ module Trackler
         Implementation.new(track, Problem.new(k, root, track))
       }
       all.each do |impl|
-        hash[impl.problem.slug] = impl
+        hash[impl.slug] = impl
       end
       hash
     end

--- a/lib/trackler/implementations.rb
+++ b/lib/trackler/implementations.rb
@@ -25,6 +25,8 @@ module Trackler
       all.length
     end
 
+    alias_method :size, :length
+
     private
 
     def all

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -48,7 +48,7 @@ module Trackler
     end
 
     def problems
-      @problems ||= implementations.map(&:problem)
+      @problems ||= implementations
     end
 
     def checklist_issue

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -36,11 +36,11 @@ module Trackler
     end
 
     def upcoming?
-      !active? && problems.length > 0
+      !active? && implementations.length > 0
     end
 
     def planned?
-      !active? && problems.length.zero?
+      !active? && implementations.length.zero?
     end
 
     def implementations

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -48,7 +48,8 @@ module Trackler
     end
 
     def problems
-      @problems ||= implementations
+      warn "DEPRECATION WARNING: A track only has implementations, call track.implementations instead"
+      implementations
     end
 
     def checklist_issue

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -4,6 +4,15 @@ require 'trackler/problem'
 require 'trackler/implementation'
 
 class ImplementationTest < Minitest::Test
+  def test_implementation_implements_the_same_methods_that_problem_does
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track, problem)
+
+    missing_methods = problem.public_methods - implementation.public_methods
+    assert_equal [], missing_methods
+  end
+
   def test_zip
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -137,7 +137,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('apple', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    assert_match %r(The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.), implementation.readme
+    assert_match %r{The SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.}, implementation.readme
   end
 
   def test_readme_uses_track_hint_instead_of_setup

--- a/test/trackler/implementations_test.rb
+++ b/test/trackler/implementations_test.rb
@@ -1,5 +1,4 @@
 require_relative '../test_helper'
-require 'trackler/implementation'
 require 'trackler/implementations'
 
 class ImplementationsTest < Minitest::Test

--- a/test/trackler/implementations_test.rb
+++ b/test/trackler/implementations_test.rb
@@ -1,5 +1,4 @@
 require_relative '../test_helper'
-require 'trackler/problem'
 require 'trackler/implementation'
 require 'trackler/implementations'
 
@@ -15,11 +14,11 @@ class ImplementationsTest < Minitest::Test
       "Hello World", "One", "Two", "Three"
     ]
     assert_equal names, implementations.map {|implementation|
-      implementation.problem.name
+      implementation.name
     }
 
     # can access it like a hash
-    assert_equal "Hello World", implementations["hello-world"].problem.name
+    assert_equal "Hello World", implementations["hello-world"].name
 
     # handles null implementations
     refute implementations["no-such-implementation"].exists?

--- a/test/trackler/implementations_test.rb
+++ b/test/trackler/implementations_test.rb
@@ -12,9 +12,7 @@ class ImplementationsTest < Minitest::Test
     names = [
       "Hello World", "One", "Two", "Three"
     ]
-    assert_equal names, implementations.map {|implementation|
-      implementation.name
-    }
+    assert_equal names, implementations.map(&:name)
 
     # can access it like a hash
     assert_equal "Hello World", implementations["hello-world"].name

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -24,9 +24,7 @@ class TrackTest < Minitest::Test
 
     slugs = %w(hello-world one two three)
     assert_equal slugs, track.problems.map(&:slug)
-    assert_equal slugs, track.implementations.map {|implementation|
-      implementation.problem.slug
-    }
+    assert_equal slugs, track.implementations.map(&:slug)
 
     # This is a sanity-check to demonstrate that this fake
     # track actually has both foregone and deprecated problems.
@@ -186,7 +184,7 @@ class TrackTest < Minitest::Test
 
   def test_track_implementations_contains_track_only_problem
     track = Trackler::Track.new('snowflake', FIXTURE_PATH)
-    refute_nil track.implementations.detect {|i| i.problem.slug == "snowflake-only"}
-    assert track.implementations.detect {|i| i.problem.slug == "snowflake-only"}.exists?
+    refute_nil track.implementations.detect {|i| i.slug == "snowflake-only"}
+    assert track.implementations.detect {|i| i.slug == "snowflake-only"}.exists?
   end
 end

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -23,7 +23,6 @@ class TrackTest < Minitest::Test
     assert_nil track.gitter
 
     slugs = %w(hello-world one two three)
-    assert_equal slugs, track.problems.map(&:slug)
     assert_equal slugs, track.implementations.map(&:slug)
 
     # This is a sanity-check to demonstrate that this fake
@@ -37,16 +36,16 @@ class TrackTest < Minitest::Test
     assert_equal(/test/i, track.test_pattern)
   end
 
-  def test_deprecated_problems
+  def test_deprecated_implementations
     track = Trackler::Track.new('fruit', FIXTURE_PATH)
     slugs = %w(apple banana cherry)
-    assert_equal slugs, track.problems.map(&:slug)
+    assert_equal slugs, track.implementations.map(&:slug)
   end
 
-  def test_problems
+  def test_implementations
     track = Trackler::Track.new('fruit', FIXTURE_PATH)
     slugs = %w(apple banana cherry)
-    assert_equal slugs, track.problems.map(&:slug)
+    assert_equal slugs, track.implementations.map(&:slug)
   end
 
   def test_img
@@ -176,10 +175,10 @@ class TrackTest < Minitest::Test
     assert track.planned?
   end
 
-  def test_track_problems_contains_track_only_problem
+  def test_track_implementations_contains_track_only_problem
     track = Trackler::Track.new('snowflake', FIXTURE_PATH)
-    refute_nil track.problems.detect {|p| p.slug == "snowflake-only"}
-    assert track.problems.detect {|p| p.slug == "snowflake-only"}.exists?
+    refute_nil track.implementations.detect {|p| p.slug == "snowflake-only"}
+    assert track.implementations.detect {|p| p.slug == "snowflake-only"}.exists?
   end
 
   def test_track_implementations_contains_track_only_problem


### PR DESCRIPTION
An `Implementation` is a `Problem`

By using composition we delegate all Problem methods to the Problem instance variable that an Implementation maintains.

This simplifies usage as users can now `implementation.slug` instead of `implementation.problem.slug` as before.

These are the public methods that an Implementation instance adds:
`[:files, :files=, :git_url, :problem, :readme, :track_id, :zip]`

Also a few refactorings in the `implementation.rb` file.

Note: The `problem` method is deprecated and will emit a `warn`ing on use.

Possibly controversial:

`Track#problems` is deprecated in favour of `Track#implementations` and will emit a warning on use.
