### PR TITLE
Deprecate Implementation#files=

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -31,6 +31,10 @@ module Trackler
       }].merge("README.md" => readme)
     end
 
+    def merge_files(new_files)
+      files.merge!(new_files)
+    end
+
     def zip
       @zip ||= file_bundle.zip do |io|
         io.put_next_entry('README.md')

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -11,7 +11,6 @@ module Trackler
     ]
 
     attr_reader :track, :problem
-    attr_writer :files
     def initialize(track, problem)
       @track = track
       @problem = problem
@@ -29,6 +28,11 @@ module Trackler
       @files ||= Hash[file_bundle.paths.map {|path|
         [path.relative_path_from(implementation_dir).to_s, File.read(path)]
       }].merge("README.md" => readme)
+    end
+
+    def files=(value)
+      warn "DEPRECATION WARNING: 'Implementation#files=' is no longer public, please use 'implementation.merge_files' instead."
+      @files = value
     end
 
     def merge_files(new_files)

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -79,14 +79,16 @@ class ImplementationTest < Minitest::Test
     refute implementation.exists?, "Not expecting apple to be implemented for track TRACK_ID"
   end
 
-  def test_override_implementation_files
+  def test_override_implementation_files_is_deprecated
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    files = { "filename" => "contents" }
-    implementation.files = files
-    assert_equal files, implementation.files
+    assert_output nil, /DEPRECATION WARNING/ do
+      files = { "filename" => "contents" }
+      implementation.files = files
+      assert_equal files, implementation.files
+    end
   end
 
   def test_implementation_merge_files

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -89,6 +89,18 @@ class ImplementationTest < Minitest::Test
     assert_equal files, implementation.files
   end
 
+  def test_implementation_merge_files
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track, problem)
+
+    new_files = { "filename" => "contents", 'another_filename' => 'contents' }
+    expected = implementation.files.merge(new_files)
+    implementation.merge_files(new_files)
+    assert_equal expected, implementation.files
+  end
+
+
   def test_ignores_example_files
     track = Trackler::Track.new('fruit', FIXTURE_PATH)
     problem = Trackler::Problem.new('imbe', FIXTURE_PATH)


### PR DESCRIPTION
Deprecate `Implementation#files=` method

The `files=` method should not be public.
Currently is is only used by x-api to add solution files to the file bundle for the 'restore' endpoint. 
See: https://github.com/exercism/x-api/blob/master/api/v1/routes/exercises.rb#L20

This PR adds the preferred method `merge_files` and adds a deprecation warning to `files=` method