### PR TITLE
Suppress blurb if it starts the description

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -77,8 +77,6 @@ module Trackler
       <<-README
 # #{readme_title}
 
-#{problem.blurb}
-
 #{readme_body}
 
 #{readme_source}
@@ -91,12 +89,19 @@ module Trackler
       problem.name
     end
 
+    def optional_blurb
+      blurb = problem.blurb
+      return '' if problem.description.start_with?(blurb)
+      "#{blurb}\n\n"
+    end
+
     def readme_body
-      [
-        problem.description,
-        implementation_hints,
-        track.hints,
-      ].reject(&:empty?).join("\n").strip
+      optional_blurb +
+        [
+          problem.description,
+          implementation_hints,
+          track.hints,
+        ].reject(&:empty?).join("\n").strip
     end
 
     def readme_source

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -9,7 +9,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    # Our archive is not binary identically reproducable :(
+    # Our archive is not binary identically reproducible :(
     archive = implementation.zip
     assert_instance_of StringIO, archive
     expected_files = ['hello_test.ext', 'world_test.ext', 'README.md']
@@ -138,6 +138,17 @@ class ImplementationTest < Minitest::Test
     implementation = Trackler::Implementation.new(track, problem)
 
     assert_match /This is the content of the track hints file/, implementation.readme
+  end
+
+  def test_blurb_not_repeated_if_same_as_start_of_description
+    mock_track = OpenStruct.new(dir: Pathname.new('dont care'), hints: 'dont care')
+    mock_problem = OpenStruct.new(
+      blurb: 'blurb', description: 'blurb then description',
+      name: 'dont care', slug: 'dont-care', source_markdown: 'dont_care'
+    )
+    implementation = Trackler::Implementation.new(mock_track, mock_problem)
+    result = implementation.readme
+    assert_equal ['blurb'], result.scan(/blurb/)
   end
 
   private


### PR DESCRIPTION
https://github.com/exercism/x-common/pull/775 moves the first line of the description of an implementation from the blurb to the description so that the description will be self contained.

If Trackler prepends the blurb to the description when it is already there, the blurb will appear to be doubled up in the readme.

This patch checks, and does not add the blurb to the readme if it matches the start of the description text.

Addresses part 1 of Issue #42
