### PR TITLE
No longer add blurb to readme

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -98,13 +98,7 @@ module Trackler
       README
     end
 
-    def optional_blurb
-      return '' if description.start_with?(blurb)
-      "#{blurb}\n\n"
-    end
-
     def readme_body
-      optional_blurb +
         [
           description,
           implementation_hints,

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -41,7 +41,7 @@ class ImplementationTest < Minitest::Test
       "sub/src/stubfile.ext" => "stub\n",
 
       # contains implementation-specific hint, but not language-specific hint
-      "README.md" => "# One\n\nThis is one.\n\n* one\n* one again\n\n* one hint\n* one more hint\n\n## Source\n\nThe internet. [http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+      "README.md" => "# One\n\n* one\n* one again\n\n* one hint\n* one more hint\n\n## Source\n\nThe internet. [http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     }
     assert_equal expected, implementation.files
   end
@@ -51,7 +51,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('banana', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    expected = "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Banana\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
     assert_equal expected, implementation.readme
   end
@@ -120,7 +120,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('apple', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    expected = "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Apple\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     assert_equal expected, implementation.readme
   end
 

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -148,17 +148,6 @@ class ImplementationTest < Minitest::Test
     assert_match /This is the content of the track hints file/, implementation.readme
   end
 
-  def test_blurb_not_repeated_if_same_as_start_of_description
-    mock_track = OpenStruct.new(dir: Pathname.new('dont care'), hints: 'dont care')
-    mock_problem = OpenStruct.new(
-      blurb: 'blurb', description: 'blurb then description',
-      name: 'dont care', slug: 'dont-care', source_markdown: 'dont_care'
-    )
-    implementation = Trackler::Implementation.new(mock_track, mock_problem)
-    result = implementation.readme
-    assert_equal ['blurb'], result.scan(/blurb/)
-  end
-
   def test_git_url
     mock_track = OpenStruct.new(repository: '[repository url]')
     mock_problem = OpenStruct.new(slug: 'slug')


### PR DESCRIPTION
The information in the blurb has been incorporated into the description, so no longer needs to be added to it when building the readme.

Ref: https://github.com/exercism/x-common/pull/775

Closes: https://github.com/exercism/trackler/issues/42
