### PR TITLE
Make Implementation#dup also dup @files

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -18,6 +18,11 @@ module Trackler
       @problem = problem
     end
 
+    def initialize_copy(original)
+      super
+      @files = original.files.dup
+    end
+
     def problem
       warn "DEPRECATION WARNING: The `problem` method is deprecated, Implementation can do everything that Problem can, so call the method directly."
       @problem

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -96,6 +96,18 @@ class ImplementationTest < Minitest::Test
     assert_equal expected, implementation.files
   end
 
+  def test_implementation_dup_files
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
+    original = Trackler::Implementation.new(track, problem)
+
+    # Ensure @files exists before `dup`ing
+    assert_instance_of Hash, original.files
+
+    duplicate = original.dup
+
+    refute_equal original.files.object_id, duplicate.files.object_id
+  end
 
   def test_ignores_example_files
     track = Trackler::Track.new('fruit', FIXTURE_PATH)


### PR DESCRIPTION
The default `dup` or `clone` behaviour is to make a shallow copy.

This provides a deep copy of the `files` instance variable as well so when they are modified
by `merge_files` the original will remain unchanged.

Thanks to @petertseng for bringing this to my attention and doing some detective work as to the cause.

Ref: https://github.com/exercism/trackler/pull/39#issuecomment-303578961