### PR TITLE
Add Implementation#language method.

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -13,6 +13,7 @@ module Trackler
 
     extend Forwardable
     def_delegators :@problem, :name, :blurb, :description, :source_markdown, :slug, :source, :metadata, :root, :active?, :deprecated?, :source_url, :description_url, :canonical_data_url, :metadata_url
+    def_delegators :@track, :language
 
     def initialize(track, problem)
       @track = track

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -168,6 +168,15 @@ class ImplementationTest < Minitest::Test
     assert_equal '[repository url]/tree/master/exercises/slug', implementation.git_url
   end
 
+  def test_language
+    expected_language = 'Expected Language'
+    mock_track = OpenStruct.new(repository: '[repository url]', language: expected_language)
+    mock_problem = OpenStruct.new(slug: 'slug')
+    implementation = Trackler::Implementation.new(mock_track, mock_problem)
+
+    assert_equal expected_language, implementation.language
+  end
+
   private
 
   def archive_filenames(zip)


### PR DESCRIPTION
This method will return the English representation of the language that the exercise is implemented in.

Note: This is NOT the track ID/slug, which you should never need to ask the Implementation for.

See: #47 