### PR TITLE
Remove ability to mutate Implementation#@files

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -39,15 +39,6 @@ module Trackler
       }].merge("README.md" => readme)
     end
 
-    def files=(value)
-      warn "DEPRECATION WARNING: 'Implementation#files=' is no longer public, please use 'implementation.merge_files' instead."
-      @files = value
-    end
-
-    def merge_files(new_files)
-      files.merge!(new_files)
-    end
-
     def zip
       @zip ||= file_bundle.zip do |io|
         io.put_next_entry('README.md')

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -73,29 +73,6 @@ class ImplementationTest < Minitest::Test
     refute implementation.exists?, "Not expecting apple to be implemented for track TRACK_ID"
   end
 
-  def test_override_implementation_files_is_deprecated
-    track = Trackler::Track.new('fake', FIXTURE_PATH)
-    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
-    implementation = Trackler::Implementation.new(track, problem)
-
-    assert_output nil, /DEPRECATION WARNING/ do
-      files = { "filename" => "contents" }
-      implementation.files = files
-      assert_equal files, implementation.files
-    end
-  end
-
-  def test_implementation_merge_files
-    track = Trackler::Track.new('fake', FIXTURE_PATH)
-    problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)
-    implementation = Trackler::Implementation.new(track, problem)
-
-    new_files = { "filename" => "contents", 'another_filename' => 'contents' }
-    expected = implementation.files.merge(new_files)
-    implementation.merge_files(new_files)
-    assert_equal expected, implementation.files
-  end
-
   def test_implementation_dup_files
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     problem = Trackler::Problem.new('hello-world', FIXTURE_PATH)


### PR DESCRIPTION
Being able to mutate the files leads to bugs where the files you think you have are not the files you actually have.

Remove the temptation to ever do this by removing support for it.

The removed methods `#files=`, `merge_files` are both now unused since (x-api) was rewritten to avoid them.

Fixes: #52 