### PR TITLE
Fix wording in assembled exercise READMEs

### DIFF
--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -106,7 +106,7 @@ module Trackler
 
     def incomplete_solutions_body
       <<-README
-## Submitting Incomplete Problems
+## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
       README
     end

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -41,7 +41,7 @@ class ImplementationTest < Minitest::Test
       "sub/src/stubfile.ext" => "stub\n",
 
       # contains implementation-specific hint, but not language-specific hint
-      "README.md" => "# One\n\n* one\n* one again\n\n* one hint\n* one more hint\n\n## Source\n\nThe internet. [http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+      "README.md" => "# One\n\n* one\n* one again\n\n* one hint\n* one more hint\n\n## Source\n\nThe internet. [http://example.com](http://example.com)\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     }
     assert_equal expected, implementation.files
   end
@@ -51,7 +51,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('banana', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    expected = "# Banana\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Banana\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and exercises/TRACK_HINTS.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
     assert_equal expected, implementation.readme
   end
@@ -109,7 +109,7 @@ class ImplementationTest < Minitest::Test
     problem = Trackler::Problem.new('apple', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, problem)
 
-    expected = "# Apple\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Problems\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Apple\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     assert_equal expected, implementation.readme
   end
 


### PR DESCRIPTION
Now that we've sorted out our terminology, we were using 'Problem'
wrong in our message about submitting incomplete solutions.

See https://github.com/exercism/discussions/issues/145

/cc @Insti 