### PR TITLE
Remove support for config.json "problems" key

### DIFF
--- a/fixtures/tracks/animal/config.json
+++ b/fixtures/tracks/animal/config.json
@@ -5,8 +5,12 @@
   "active": true,
   "test_pattern": "a.*animal",
   "ignore_pattern": "[^_]example",
-  "problems": [
-    "dog"
+  "exercises": [
+    {
+      "slug": "dog",
+      "difficulty": 1,
+      "topics": []
+    }
   ],
   "deprecated": [],
   "foregone": [

--- a/fixtures/tracks/fake/config.json
+++ b/fixtures/tracks/fake/config.json
@@ -5,11 +5,6 @@
   "image": "fake.png",
   "checklist_issue": 5,
   "active": true,
-  "problems": [
-    "good",
-    "bad",
-    "ugly"
-  ],
   "exercises": [
       {
         "slug": "hello-world" ,

--- a/fixtures/tracks/fruit/config.json
+++ b/fixtures/tracks/fruit/config.json
@@ -6,10 +6,22 @@
   "active": true,
   "test_pattern": "\\.tst$",
   "gitter": "xfruit",
-  "problems": [
-    "apple",
-    "banana",
-    "cherry"
+  "exercises": [
+    {
+      "slug": "apple",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "banana",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "cherry",
+      "difficulty": 1,
+      "topics": []
+    }
   ],
   "deprecated": [
     "four"

--- a/fixtures/tracks/jewels/config.json
+++ b/fixtures/tracks/jewels/config.json
@@ -3,8 +3,12 @@
   "language": "Fancy Stones",
   "repository": "https://github.com/exercism/xjewels",
   "active": true,
-  "problems": [
-    "hello-world"
+  "exercises": [
+    {
+      "slug": "hello-world",
+      "difficulty": 1,
+      "topics": []
+    }
   ],
   "deprecated": [],
   "foregone": []

--- a/fixtures/tracks/shoes/config.json
+++ b/fixtures/tracks/shoes/config.json
@@ -3,8 +3,12 @@
   "language": "Shoes & Boots",
   "repository": "https://github.com/exercism/xshoes",
   "active": false,
-  "problems": [
-    "hello-world"
+  "exercises": [
+    {
+      "slug": "hello-world",
+      "difficulty": 1,
+      "topics": []
+    }
   ],
   "deprecated": [],
   "foregone": []

--- a/fixtures/tracks/snowflake/config.json
+++ b/fixtures/tracks/snowflake/config.json
@@ -4,11 +4,27 @@
   "repository": "https://example.com/exercism/xsnowflake",
   "active": true,
   "test_pattern": "\\.tst$",
-  "problems": [
-    "apple",
-    "banana",
-    "cherry",
-    "snowflake-only"
+  "exercises": [
+    {
+      "slug": "apple",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "banana",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "cherry",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "snowflake-only",
+      "difficulty": 1,
+      "topics": []
+    }
   ],
   "deprecated": [
   ],

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -136,19 +136,8 @@ module Trackler
       filepaths.find(-> { '' }) { |filepath| File.exist? filepath }
     end
 
-    # The slugs for the problems that are currently in the track.
-    # We deprecated the old array of problem slugs in favor of an array
-    # containing richer metadata about a given exercise.
     def active_slugs
-      __active_slugs__.empty? ? __active_slugs_deprecated_key__ : __active_slugs__
-    end
-
-    def __active_slugs__
       (config["exercises"] || []).map { |ex| ex["slug"] }
-    end
-
-    def __active_slugs_deprecated_key__
-      config["problems"] || []
     end
 
     def foregone_slugs


### PR DESCRIPTION
The deprecated "problems" key in the `config.json` is no longer used by the real tracks, 
they all use the "exercises" key.

Ref exercism/meta#4