### PR TITLE
Add generic support for orgmode doc files

### DIFF
--- a/fixtures/tracks/fake/docs/STRAY.md
+++ b/fixtures/tracks/fake/docs/STRAY.md
@@ -1,0 +1,1 @@
+![](/docs/img/test.jpg)

--- a/lib/trackler/doc_file.rb
+++ b/lib/trackler/doc_file.rb
@@ -1,0 +1,75 @@
+class DocFile
+  DEFAULT_IMAGE_PATH = "/docs/img"
+
+  def self.find(basename:, track_dir:)
+    dir = File.join(track_dir, "docs")
+
+    [
+      MarkdownFile.new(basename: basename, docs_dir: dir),
+      OrgmodeFile.new(basename: basename, docs_dir: dir),
+    ].detect(&:exist?) || NullFile.new(basename: basename, docs_dir: dir)
+  end
+
+  attr_reader :basename, :dir
+  def initialize(basename:, docs_dir:)
+    @basename = basename
+    @dir = docs_dir
+  end
+
+  def render(image_path: DEFAULT_IMAGE_PATH)
+    body.gsub(img_src, img_dst(image_path))
+  end
+
+  def name
+    "%s.%s" % [basename, extension]
+  end
+
+  def extension
+    "md"
+  end
+
+  def exist?
+    File.exist?(path)
+  end
+
+  private
+
+  def body
+    File.read(path)
+  end
+
+  def path
+    File.join(dir, name)
+  end
+
+  def img_src
+    Regexp.new("]\\(%s" % DEFAULT_IMAGE_PATH)
+  end
+
+  def img_dst(image_path)
+    "](%s" % image_path.gsub(Regexp.new("/$"), "")
+  end
+end
+
+class OrgmodeFile < DocFile
+  def body
+    Orgmode::Parser.new(File.read(path)).to_markdown
+  end
+
+  def extension
+    "org"
+  end
+end
+
+class MarkdownFile < DocFile
+end
+
+class NullFile < DocFile
+  def render(image_path:"")
+    ""
+  end
+
+  def exist?
+    false
+  end
+end

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -8,7 +8,6 @@ module Trackler
   # Track is a collection of exercises in a given language.
   class Track
     TOPICS = %w(about installation tests learning resources)
-    DEFAULT_IMAGE_PATH = "/docs/img"
 
     Image = Struct.new(:path) do
       def exists?
@@ -88,7 +87,7 @@ module Trackler
       config.fetch('ignore_pattern', 'example')
     end
 
-    def docs(image_path: DEFAULT_IMAGE_PATH)
+    def docs(image_path: DocFile::DEFAULT_IMAGE_PATH)
       OpenStruct.new(docs_by_topic(image_path))
     end
 
@@ -116,18 +115,10 @@ module Trackler
     end
 
     def hints
-      if File.exist?(track_hints_filename)
-        File.read(track_hints_filename)
-      else
-        ""
-      end
+      docfile = DocFile.find(basename: 'EXERCISE_README_INSERT', track_dir: dir).render
     end
 
     private
-
-    def track_hints_filename
-      File.join(dir, 'docs', 'EXERCISE_README_INSERT.md')
-    end
 
     def active_slugs
       (config["exercises"] || []).map { |ex| ex["slug"] }
@@ -156,33 +147,14 @@ module Trackler
       File.join(dir, "config.json")
     end
 
-    def document_contents(topic)
-      filename = document_filename(topic)
-      case filename
-      when /\.md$/
-        File.read(filename)
-      when /\.org$/
-        Orgmode::Parser.new(File.read(filename)).to_markdown
-      else
-        ''
-      end
-    end
-
     def docs_by_topic(image_path)
-      src = Regexp.new("]\\(%s" % DEFAULT_IMAGE_PATH)
-      dst = "](%s" % image_path.gsub(Regexp.new("/$"), "")
       Hash[
         TOPICS.zip(
           TOPICS.map { |topic|
-            document_contents(topic).gsub(src, dst)
+            DocFile.find(basename: topic.upcase, track_dir: dir).render(image_path: image_path)
           }
         )
       ]
-    end
-
-    def document_filename(topic)
-      path = File.join(dir, "docs", topic.upcase)
-      Dir.glob("%s.*" % path).sort.first
     end
 
     def svg_icon

--- a/test/trackler/doc_file_test.rb
+++ b/test/trackler/doc_file_test.rb
@@ -1,0 +1,52 @@
+require_relative '../test_helper'
+require 'trackler'
+
+class DocFileTest < Minitest::Test
+  def test_find_orgmode_file
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    file = DocFile.find(basename: 'ABOUT', track_dir: track.dir)
+
+    assert_equal "ABOUT.org", file.name
+    expected = "Language Information\n"
+    assert_equal expected, file.render
+  end
+
+  def test_find_markdown_file
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    file = DocFile.find(basename: 'TESTS', track_dir: track.dir)
+
+    assert_equal "TESTS.md", file.name
+    expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
+    assert_equal expected, file.render
+  end
+
+  def test_handle_image_paths
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+
+    file = DocFile.find(basename: 'STRAY', track_dir: track.dir)
+    expected = "![](/alt/test.jpg)\n"
+    assert_equal expected, file.render(image_path: "/alt")
+
+    file = DocFile.find(basename: 'STRAY', track_dir: track.dir)
+    expected = "![](/alt/test.jpg)\n"
+    assert_equal expected, file.render(image_path: "/alt/")
+  end
+
+  def test_do_not_override_full_urls
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    file = DocFile.find(basename: 'TESTS', track_dir: track.dir)
+
+    assert_equal "TESTS.md", file.name
+    expected = "Running\n![](http://example.org/abc/docs/img/test.jpg)\n"
+    assert_equal expected, file.render(image_path: "/alt")
+  end
+
+  def test_handle_unknown_file
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    file = DocFile.find(basename: 'UNKNOWN', track_dir: track.dir)
+
+    assert_equal "UNKNOWN.md", file.name
+    assert_equal "", file.render(image_path: "/img")
+    refute file.exist?, "Null files shouldn't exist"
+  end
+end


### PR DESCRIPTION
The files in 'docs' could be either markdown or orgmode. This finds whatever is present
even if there is a mix.

This leaves a dirty hack for the EXERCISE_README_INSERT fallback, which
I think is fine since we're just about ready to remove it per
https://github.com/exercism/meta/issues/5

Fixes #64