### PR TITLE
Delete the Problem(s) classes

### DIFF
--- a/lib/trackler.rb
+++ b/lib/trackler.rb
@@ -5,7 +5,6 @@ module Trackler
   def self.reset
     @path = nil
     @implementations = nil
-    @problems = nil
     @specifications = nil
     @tracks = nil
     @todos = nil
@@ -27,10 +26,6 @@ module Trackler
 
   def self.specifications
     @specifications ||= Specifications.new(path)
-  end
-
-  def self.problems
-    @problems ||= Problems.new(path)
   end
 
   def self.tracks

--- a/lib/trackler/problem.rb
+++ b/lib/trackler/problem.rb
@@ -1,7 +1,0 @@
-require_relative 'specification'
-
-module Trackler
-  # Problem is a language-independent definition of an exercise.
-  class Problem < Trackler::Specification
-  end
-end

--- a/lib/trackler/problems.rb
+++ b/lib/trackler/problems.rb
@@ -1,7 +1,0 @@
-require_relative 'specifications'
-
-module Trackler
-  # Problems is the collection of problems that we have metadata for.
-  class Problems < Trackler::Specifications
-  end
-end

--- a/test/trackler_test.rb
+++ b/test/trackler_test.rb
@@ -14,12 +14,6 @@ class TracklerTest < Minitest::Test
     assert_nil Trackler.specifications.detect { |p| p.slug == "snowflake-only" }
   end
 
-  def test_problems_does_not_contain_track_specific_problems
-    Trackler.use_fixture_data
-
-    assert_nil Trackler.problems.detect { |p| p.slug == "snowflake-only" }
-  end
-
   def test_implementations_does_contain_track_specific_problems
     Trackler.use_fixture_data
 


### PR DESCRIPTION
The downstream dependencies no longer rely on these, referring
instead to the Specification(s) classes.

Closes #40