### PR TITLE
Delete support for deprecated readme insert filenames

### DIFF
--- a/fixtures/tracks/animal/SETUP.md
+++ b/fixtures/tracks/animal/SETUP.md
@@ -1,1 +1,0 @@
-This is the content of the setup.md file, which will be overwritten when track_hints.md exists.

--- a/fixtures/tracks/animal/exercises/TRACK_HINTS.md
+++ b/fixtures/tracks/animal/exercises/TRACK_HINTS.md
@@ -1,1 +1,0 @@
-This is the content of the track hints file

--- a/fixtures/tracks/fruit/SETUP.md
+++ b/fixtures/tracks/fruit/SETUP.md
@@ -1,1 +1,0 @@
-The SETUP.md file is deprecated, and docs/EXERCISE_README_INSERT.md should be used.

--- a/fixtures/tracks/jewels/exercises/TRACK_HINTS.md
+++ b/fixtures/tracks/jewels/exercises/TRACK_HINTS.md
@@ -1,1 +1,0 @@
-This is the content of the track hints file

--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -129,11 +129,7 @@ module Trackler
     private
 
     def track_hints_filename
-      current = [File.join('docs', 'EXERCISE_README_INSERT.md')]
-      deprecated = [File.join('exercises', 'TRACK_HINTS.md'), 'SETUP.md']
-
-      filepaths = (current + deprecated).map { |name| dir.join(name) }
-      filepaths.find(-> { '' }) { |filepath| File.exist? filepath }
+      File.join(dir, 'docs', 'EXERCISE_README_INSERT.md')
     end
 
     def active_slugs

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -51,7 +51,7 @@ class ImplementationTest < Minitest::Test
     specification = Trackler::Specification.new('banana', FIXTURE_PATH)
     implementation = Trackler::Implementation.new(track, specification)
 
-    expected = "# Banana\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\nThe SETUP.md file is deprecated, and docs/EXERCISE_README_INSERT.md should be used.\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
+    expected = "# Banana\n\n* banana\n* banana again\n\n* banana specific hints.\n* a hint\n* another hint\n\n## Source\n\n[http://example.com](http://example.com)\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
 
     assert_equal expected, implementation.readme
   end
@@ -111,30 +111,6 @@ class ImplementationTest < Minitest::Test
 
     expected = "# Apple\n\n* apple\n* apple again\n\n## Source\n\nThe internet.\n\n## Submitting Incomplete Solutions\nIt's possible to submit an incomplete solution so you can see how others have completed the exercise.\n\n"
     assert_equal expected, implementation.readme
-  end
-
-  def test_readme_uses_track_hint_in_precedence_of_setup
-    track = Trackler::Track.new('animal', FIXTURE_PATH)
-    specification = Trackler::Specification.new('dog', FIXTURE_PATH)
-    implementation = Trackler::Implementation.new(track, specification)
-
-    assert_match /This is the content of the track hints file/, implementation.readme
-  end
-
-  def test_readme_uses_setup_when_track_hints_is_missing
-    track = Trackler::Track.new('fruit', FIXTURE_PATH)
-    specification = Trackler::Specification.new('apple', FIXTURE_PATH)
-    implementation = Trackler::Implementation.new(track, specification)
-
-    assert_match %r{The SETUP.md file is deprecated, and docs/EXERCISE_README_INSERT.md should be used.}, implementation.readme
-  end
-
-  def test_readme_uses_track_hint_instead_of_setup
-    track = Trackler::Track.new('jewels', FIXTURE_PATH)
-    specification = Trackler::Specification.new('hello-world', FIXTURE_PATH)
-    implementation = Trackler::Implementation.new(track, specification)
-
-    assert_match /This is the content of the track hints file/, implementation.readme
   end
 
   def test_git_url

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -200,18 +200,6 @@ class TrackTest < Minitest::Test
     assert_equal expected, track.hints
   end
 
-  def test_track_hints_deprecated_location_slash_exercises_slash_track_hints
-    track = Trackler::Track.new('animal', FIXTURE_PATH)
-    expected = "This is the content of the track hints file\n"
-    assert_equal expected, track.hints
-  end
-
-  def test_track_hints_deprecated_location_slash_setup
-    track = Trackler::Track.new('fruit', FIXTURE_PATH)
-    expected = "The SETUP.md file is deprecated, and docs/EXERCISE_README_INSERT.md should be used.\n"
-    assert_equal expected, track.hints
-  end
-
   def test_track_hints_not_present
     track = Trackler::Track.new('shoes', FIXTURE_PATH)
     expected = ""


### PR DESCRIPTION
There was a cascade of renames over the past few years, and we finally found a name we like.
We've updated all the language track repositories to rename the file to the name we decided on,
which lets us remove a bit of cruft.

Yay.

This closes https://github.com/exercism/meta/issues/5