### PR TITLE
Remove deprecated positional argument for track docs

### DIFF
--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -88,11 +88,8 @@ module Trackler
       config.fetch('ignore_pattern', 'example')
     end
 
-    def docs(positional_image_path_which_is_deprecated = nil, image_path: nil)
-      if positional_image_path_which_is_deprecated
-        warn "DEPRECATION WARNING:\ntrack.docs: Positional argument is deprecated, please use keyword argument 'image_path:' instead\neg: track.docs(image_path: #{positional_image_path_which_is_deprecated.inspect})\n"
-      end
-      OpenStruct.new(docs_by_topic(image_path || positional_image_path_which_is_deprecated || DEFAULT_IMAGE_PATH))
+    def docs(image_path: DEFAULT_IMAGE_PATH)
+      OpenStruct.new(docs_by_topic(image_path))
     end
 
     def img(file_path)

--- a/test/trackler/track_test.rb
+++ b/test/trackler/track_test.rb
@@ -90,14 +90,6 @@ class TrackTest < Minitest::Test
     assert_equal expected, track.docs(image_path: "/alt").tests
   end
 
-  def test_docs_with_alternate_image_path_using_positional_argument
-    track = Trackler::Track.new('fake', FIXTURE_PATH)
-    assert_output nil, /DEPRECATION WARNING/ do
-      expected = "Installing\n![](/positional/test.jpg)\n"
-      assert_equal expected, track.docs('/positional').installation
-    end
-  end
-
   def test_docs_accessible_as_object
     track = Trackler::Track.new('fake', FIXTURE_PATH)
     expected = "Language Information\n"


### PR DESCRIPTION
The downstream dependencies all use the keyword argument for the image_path. /cc @Insti 