### PR TITLE
Delete stray assignment

### DIFF
--- a/lib/trackler/track.rb
+++ b/lib/trackler/track.rb
@@ -115,7 +115,7 @@ module Trackler
     end
 
     def hints
-      docfile = DocFile.find(basename: 'EXERCISE_README_INSERT', track_dir: dir).render
+      DocFile.find(basename: 'EXERCISE_README_INSERT', track_dir: dir).render
     end
 
     private


### PR DESCRIPTION
I'm not sure how I left this in.

It was part of a large refactoring. I suspect that this method had a number of changes where earlier on it made sense to have a variable, and then when it no longer did I didn't notice.