### PR TITLE
Require english library before running tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'English'
 ENV['RACK_ENV'] = 'test'
 
 require 'simplecov'


### PR DESCRIPTION
The test helper is referencing the PROCESS_ID global variable, which is defined by the English
library.