### PR TITLE
Use static exercise README if it is present

### DIFF
--- a/fixtures/tracks/fake/exercises/two/README.md
+++ b/fixtures/tracks/fake/exercises/two/README.md
@@ -1,0 +1,1 @@
+custom readme for 'two'

--- a/lib/trackler/implementation.rb
+++ b/lib/trackler/implementation.rb
@@ -48,7 +48,7 @@ module Trackler
     end
 
     def readme
-      @readme ||= assemble_readme
+      @readme ||= static_readme || assemble_readme
     end
 
     def git_url
@@ -82,6 +82,11 @@ module Trackler
 
     def exercise_dir
       File.join('exercises', slug)
+    end
+
+    def static_readme
+      path = File.join(implementation_dir, 'README.md')
+      return File.read(path) if File.exist?(path)
     end
 
     def assemble_readme

--- a/test/trackler/implementation_test.rb
+++ b/test/trackler/implementation_test.rb
@@ -130,6 +130,13 @@ class ImplementationTest < Minitest::Test
     assert_equal expected_language, implementation.language
   end
 
+  def test_prefer_static_readme_if_present
+    track = Trackler::Track.new('fake', FIXTURE_PATH)
+    specification = Trackler::Specification.new('two', FIXTURE_PATH)
+    implementation = Trackler::Implementation.new(track, specification)
+    assert_equal "custom readme for 'two'\n", implementation.readme
+  end
+
   #### DEPRECATION TESTS: HINTS ####
   # These can be removed when all tracks have renamed their
   # HINTS.md files to .meta/hints.md


### PR DESCRIPTION
This allows us to hook into the new exercise READMEs that get generated from configlet. See https://github.com/exercism/meta/issues/15