### PR TITLE
Fix call to configlet lint command

### DIFF
--- a/bin/verify-configs
+++ b/bin/verify-configs
@@ -2,7 +2,7 @@
 
 status = 0
 Dir.glob("tracks/*").each do |path|
-  `bin/configlet #{path}`
+  `bin/configlet lint #{path}`
   unless $?.success?
     puts "ERROR: %s" % path
     status = $?.to_i


### PR DESCRIPTION
Running `./bin/verify-configs` fails because of an invalid call the the underlying `configlet` command. This change adds the appropriate `configlet lint` subcommand to fix the unknown command errors. 

```
Run 'bin/configlet --help' for usage.
-> unknown command "tracks/dart" for "bin/configlet"
ERROR: tracks/dart
```